### PR TITLE
Fix #9: drop replay(_:on:) for Drawing.append(contentsOf:); bump OCCTSwift to 0.150

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "2dfb1e3af37fb0a5d6ab01519ae878d5cc1e7a165100cc612218d319825fb87c",
+  "originHash" : "db284712ce0bffcbf9bf83ffa3fea4f24888e7e4e8dc3a9939aa227e3f22494f",
   "pins" : [
     {
       "identity" : "occtswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "dd285dbbae585cc396c07fab880fc19235659dcb",
-        "version" : "0.147.0"
+        "revision" : "512396c8805de3dce7eac33fb602a90020fc1c9e",
+        "version" : "0.151.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.147.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.150.0"),
     ],
     targets: [
         .target(

--- a/Sources/DrawingComposer/Composer.swift
+++ b/Sources/DrawingComposer/Composer.swift
@@ -227,22 +227,22 @@ public enum Composer {
                   sf.position.count == 2, sf.leaderTo.count == 2 else { continue }
             let symbol = SurfaceFinishSymbol(rawValue: sf.symbol ?? "machiningRequired")
                          ?? .machiningRequired
-            replay(DrawingAnnotation.surfaceFinish(
+            item.drawing.append(contentsOf: DrawingAnnotation.surfaceFinish(
                 at: SIMD2(sf.position[0], sf.position[1]),
                 leaderTo: SIMD2(sf.leaderTo[0], sf.leaderTo[1]),
                 ra: sf.ra, symbol: symbol, method: sf.method
-            ), on: item.drawing)
+            ))
         }
 
         for g in spec.gdt ?? [] {
             guard let item = byName[g.view], g.position.count == 2,
                   let symbol = GDTSymbol(rawValue: g.symbol) else { continue }
             let leader = g.leaderTo.flatMap { $0.count == 2 ? SIMD2($0[0], $0[1]) : nil }
-            replay(DrawingAnnotation.featureControlFrame(
+            item.drawing.append(contentsOf: DrawingAnnotation.featureControlFrame(
                 at: SIMD2(g.position[0], g.position[1]),
                 symbol: symbol, tolerance: g.tolerance,
                 datums: g.datums ?? [], leaderTo: leader
-            ), on: item.drawing)
+            ))
         }
 
         for d in spec.dimensions ?? [] {
@@ -276,24 +276,11 @@ public enum Composer {
         }
     }
 
-    /// Re-emit a list of `DrawingAnnotation` onto a `Drawing` via its typed
-    /// add-* methods. Workaround for the absence of public
-    /// `Drawing.appendAnnotation(_:)` — see OCCTSwift#83.
-    static func replay(_ anns: [DrawingAnnotation], on drawing: Drawing) {
-        for ann in anns {
-            switch ann {
-            case .centreline(let c):
-                drawing.addCentreLine(from: c.from, to: c.to, style: c.style, id: c.id)
-            case .centermark(let m):
-                drawing.addCentermark(centre: m.centre, extent: m.extent, style: m.style, id: m.id)
-            case .textLabel(let t):
-                drawing.addTextLabel(t.text, at: t.position, height: t.height,
-                                     rotation: t.rotation, id: t.id)
-            case .hatch, .cuttingPlaneLine:
-                break
-            }
-        }
-    }
+    // The previous in-house `replay(_:on:)` helper has been removed: the
+    // upstream `Drawing.append(contentsOf:)` API (OCCTSwift v0.148+, closing
+    // OCCTSwift#84) now dispatches every `DrawingAnnotation` case
+    // exhaustively, including `.hatch` / `.cuttingPlaneLine` / `.balloon`
+    // (v0.150) which the local switch silently dropped.
 
     // MARK: - Scale (ISO 5455)
 


### PR DESCRIPTION
Closes #9.

## Summary

`Composer.replay(_:on:)` was a per-case `DrawingAnnotation` dispatcher with two known issues:

1. **Compile break against OCCTSwift ≥ 0.149** — silently-dropped `.hatch` / `.cuttingPlaneLine` cases turned into a hard "switch must be exhaustive" the moment v0.150 added `.balloon`. Downstream consumers were forced to pin OCCTSwift at `[0.148, 0.149)` to keep the package buildable.
2. **Maintenance treadmill** — every new annotation case in OCCTSwift required a matching switch update here.

OCCTSwift v0.148 (closing OCCTSwift#84) shipped a public exhaustive dispatcher: `Drawing.append(_:)` / `Drawing.append(contentsOf:)`. Adopting it lets us delete `replay()` outright.

## Changes

- `Composer.swift`:
  - `replay(DrawingAnnotation.surfaceFinish(...), on: drawing)` → `drawing.append(contentsOf: DrawingAnnotation.surfaceFinish(...))`
  - `replay(DrawingAnnotation.featureControlFrame(...), on: drawing)` → `drawing.append(contentsOf: DrawingAnnotation.featureControlFrame(...))`
  - Removed the `static func replay(_:on:)` helper.
- `Package.swift`: OCCTSwift dep `from: "0.147.0"` → `from: "0.150.0"`. Downstream gets v0.149's `Sheet.standardLayout` + `Drawing.addAutoDimensions` + `DrawingTolerance` and v0.150's `PDFWriter` / `SVGWriter` / `Balloon` / `BillOfMaterials`.

## Verification

- `swift build` clean against OCCTSwift 0.150.0.
- No tests in this package, but the `drawing-export` happy path is unchanged — the only call sites for the removed `replay(...)` were the two annotation factories, which now flow through `append(contentsOf:)`.
- Verified the upstream `Drawing.append(contentsOf:)` covers every `DrawingAnnotation` case (including `.hatch` and `.cuttingPlaneLine` which the old `replay()` dropped), so the new code is strictly more correct in addition to being shorter.

## Downstream

OCCTSwiftPartsAgent has been pinned to OCCTSwiftScripts `from: "0.5.0"` + OCCTSwift `[0.148, 0.149)` since #9 surfaced. Once this lands and a release is cut, the consumer can bump to OCCTSwift `from: "0.150.0"` and pick up the additive features in one retrofit commit.
