### PR TITLE
Drop set-metadata rootNodes warmup; bump OCCTSwift to 0.156.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1186f57ef76c1159337c99d680d277e6786eb40d5dfb2c045f0b701d1d44269a",
+  "originHash" : "7a9aed98b52ee0df0f36f74658ba11fed13b0b8cd2305fe53d9ecbbcf4d5fe3a",
   "pins" : [
     {
       "identity" : "occtswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "356e2c58bbc789eec4cf353646f8a28cf4745200",
-        "version" : "0.156.2"
+        "revision" : "085345e229c151c303af433d360c1e2c915c9050",
+        "version" : "0.156.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.156.2"),
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.156.3"),
         // OCCTSwiftViewport: revision-pinned because the OffscreenRenderer
         // (closing OCCTSwiftViewport#18) hasn't been cut as a release yet.
         // Bump to `from: "<tag>"` when a release containing OffscreenRenderer

--- a/Sources/occtkit/Commands/SetMetadata.swift
+++ b/Sources/occtkit/Commands/SetMetadata.swift
@@ -88,13 +88,6 @@ enum SetMetadataCommand: Subcommand {
     static func run(args: [String]) throws -> Int32 {
         let req = try parseRequest(args: args)
         let document = try InspectAssemblyCommand.loadDocument(path: req.inputPath)
-        // Touch rootNodes once before any node(at:) lookup. Without this,
-        // OCCTSwift v0.156.x's Document.node(at:) returns nil for labelId 0
-        // (the document main label) on a freshly-loaded STEP doc — the XCAF
-        // shape tool isn't registered until rootNodes is accessed. Costs an
-        // unused property read; should go away once OCCTSwift's node(at:)
-        // does the eager registration itself.
-        _ = document.rootNodes.count
 
         let target: AssemblyNode = try {
             switch req.scope {


### PR DESCRIPTION
OCCTSwift v0.156.3 ([gsdali/OCCTSwift#95](https://github.com/gsdali/OCCTSwift/issues/95)) made `Document.node(at:)` register top-level labels eagerly before the `LabelIsNull` check, so the lazy-init quirk that motivated the `_ = document.rootNodes.count` warmup in `set-metadata` no longer happens.

Removed the warmup line + its rationale comment. Bumped OCCTSwift dep from `from: "0.156.2"` to `from: "0.156.3"` to make the 'requires #95 fix' invariant readable at the dep declaration (the SPM resolver was already picking up 0.156.3 as the highest matching of 0.156.2).

Smoke verified: `set-metadata --scope component --component-id 0 --title post-#95-fix` against the v0.6.0 bracket STEP applies the title and writes the XBF cleanly without the warmup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)