### PR TITLE
Prep for Swift Package Index listing (target: OCCT 8.0.0 GA day)

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,15 @@
+# Swift Package Index build / documentation config.
+# https://swiftpackageindex.com/SwiftPackageIndex/SwiftPackageIndex-Server/main/documentation/spidocumentation/spi-yml
+version: 1
+builder:
+  configs:
+    # Documented Swift version + platform pair for the build matrix.
+    # OCCTSwift's xcframework is arm64 macOS 12+ / iOS 15+; this package
+    # currently targets macOS 15+ (per Package.swift) because the dev
+    # machine pinned macOS 15 — iOS support is an open question for a
+    # future minor.
+    - documentation_targets:
+        - ScriptHarness
+        - DrawingComposer
+      swift_version: "6.0"
+      platform: macos-spm

--- a/README.md
+++ b/README.md
@@ -45,7 +45,23 @@ printf '{"args":["a.brep"]}\n{"args":["b.brep"]}\n' | occtkit graph-validate --s
 make uninstall
 ```
 
-Subcommands: `run`, `graph-validate`, `graph-compact`, `graph-dedup`, `graph-query`, `graph-ml`, `feature-recognize`, `dxf-export`, `drawing-export`, `reconstruct`. `occtkit --help` lists them with one-line summaries.
+Subcommands (26 verbs as of v0.8.1):
+
+| Domain | Verbs |
+|---|---|
+| Script host | `run` |
+| Topology graph | `graph-validate`, `graph-compact`, `graph-dedup`, `graph-query`, `graph-ml` |
+| Drawings & export | `dxf-export`, `drawing-export` |
+| Composition | `compose-sheet-metal`, `reconstruct` |
+| Construction | `transform`, `boolean`, `pattern` |
+| Introspection | `metrics`, `query-topology`, `measure-distance`, `feature-recognize` |
+| I/O | `load-brep`, `import` |
+| Engineering analysis | `check-thickness`, `analyze-clearance`, `heal` |
+| Mesh | `mesh`, `simplify-mesh` |
+| Render | `render-preview` |
+| XCAF | `inspect-assembly`, `set-metadata` |
+
+`occtkit --help` lists them with one-line summaries. Each verb accepts both flag-form and JSON-form (stdin or file path) input, plus a generic `--serve` mode that reads JSONL `{"args":[...]}` requests and emits JSONL envelopes — used by OCCTMCP and any other JSON-driven consumer.
 
 > **Note**: 2D constraint solving (previously the `solve-sketch` verb) has been removed from occtkit to keep this project free of closed-source dependencies. Downstream consumers that need constraint-based sketch solving should wire up their own solver (e.g., via a separate CLI) and call it outside occtkit.
 
@@ -201,8 +217,25 @@ try ctx.emit(description: "Parametric L-bracket")
 - **output.step**: combined geometry for external tools (FreeCAD, ezdxf, STEPUtils, etc.)
 - **manifest.json**: body metadata (IDs, colors, names)
 
+## Use as an SPM library
+
+`ScriptHarness` and `DrawingComposer` are exposed as library products for in-process consumers:
+
+```swift
+.package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "0.8.1"),
+```
+
+```swift
+.product(name: "ScriptHarness", package: "OCCTSwiftScripts"),
+.product(name: "DrawingComposer", package: "OCCTSwiftScripts"),
+```
+
+The `occtkit` executable is a separate target — install via the `Makefile` above when you want the command-line surface.
+
 ## Requirements
 
 - macOS 15+
 - Swift 6.0+
-- OCCTSwift (local path dependency at `../OCCTSwift`)
+- [OCCTSwift](https://github.com/gsdali/OCCTSwift) `>= 0.165.0` (resolved transitively via SPM; xcframework rebuilt against OCCT 8.0.0 beta1, will move to OCCT 8.0.0 GA in v0.9.0)
+- [OCCTSwiftViewport](https://github.com/gsdali/OCCTSwiftViewport) `>= 0.50.0` (transitive; powers `render-preview`)
+- [OCCTSwiftMesh](https://github.com/gsdali/OCCTSwiftMesh) `>= 0.1.0` (transitive; powers `simplify-mesh`)


### PR DESCRIPTION
Gets the repo SPI-ready ahead of the OCCT 8.0.0 GA bump in #36. SPI submission itself is a one-line PR against [SwiftPackageIndex/PackageList](https://github.com/SwiftPackageIndex/PackageList) on 2026-05-07.

## Changes

### README
- Refreshed subcommand table to all 26 verbs as of v0.8.1 (was 10 verbs, predating v0.8.0's OCCTMCP-driver batch). Organised by domain.
- Added an **Use as an SPM library** section with the `Package.swift` snippet for `ScriptHarness` / `DrawingComposer` consumers — the typical SPI-discovered consumption path.
- Replaced the stale 'OCCTSwift (local path dependency at `../OCCTSwift`)' Requirements line with the accurate transitive dep set + version floors. SPI's listing card scrapes the README — wanted this current for the listing day.

### `.spi.yml` (new)
- Declares `documentation_targets: [ScriptHarness, DrawingComposer]` for SPI's auto-built DocC site (`occtkit` is an executable target so it doesn't surface as docs).
- Pins `swift_version: '6.0'` + `platform: macos-spm` for SPI's build matrix.

### GitHub repo metadata (applied via `gh repo edit`)
- Repository description updated: `occtkit CLI + ScriptHarness for OCCTSwift — 26 headless verbs (compose / reconstruct / drawing-export / metrics / mesh / render-preview / XCAF / ...) over OCCT 8.0.0 BREP geometry, JSON-driven, OCCTMCP-ready`.
- Added 18 topics: `cad`, `cad-tools`, `opencascade`, `occt`, `parametric-design`, `brep`, `swift`, `swift-package`, `cli`, `3d-modeling`, `step`, `iges`, `dxf`, `sheet-metal`, `occtswift`, `occtmcp`, `swift6`, `macos`. SPI uses topics for search relevance.

## What's left for GA day

1. Bump `Package.swift` to OCCTSwift `from: "1.0.0"` (the v0.9.0 "OCCT 8.0.0 GA" PR already planned in #36).
2. Submit `SwiftPackageIndex/PackageList#packages.json` PR adding `https://github.com/gsdali/OCCTSwiftScripts.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)