### PR TITLE
Bump OCCTSwiftTools floor to from: 0.6.0 (closes #42)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "d34fe67e5e65610d7559dc20c9d28b7ab655a1bca5c384710162913f9ecf989f",
+  "originHash" : "9fcef339be64008d38393e50e167b22041b790e7759011d059c7646ee64ef8da",
   "pins" : [
     {
       "identity" : "occtswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "3cca0730cf3fe3df722a9542ecc3e00d90fe5076",
-        "version" : "0.169.0"
+        "revision" : "c37fcff1b99f557f2572b209964abee699a2b7cc",
+        "version" : "0.170.1"
       }
     },
     {
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "b906f7487246dd59a6243b28efbbd47704e9908d",
         "version" : "0.6.0"
+      }
+    },
+    {
+      "identity" : "occtswiftio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gsdali/OCCTSwiftIO.git",
+      "state" : {
+        "revision" : "1905299e476e5fbe19ec927aa44565cc59efc09a",
+        "version" : "0.1.0"
       }
     },
     {
@@ -33,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftTools.git",
       "state" : {
-        "revision" : "31fdb8962509698c72aa391c203ae030bfa00216",
-        "version" : "0.4.1"
+        "revision" : "5e6dca35801966f7efc399c734a9d9739e48ec70",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,26 @@ let package = Package(
         // share with OCCTSwiftAIS (a sibling toolkit). We declare both as
         // direct deps below.
         .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "0.55.0"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "0.4.1"),
+        // OCCTSwiftTools v0.6.0 split file-I/O off into a sibling repo
+        // (OCCTSwiftIO) so headless consumers don't drag in Viewport just to
+        // load a STEP file. We only use Tools for the bridge-layer
+        // CADFileLoader.shapeToBodyAndMetadata in RenderPreview, which
+        // legitimately needs Viewport, so the Tools dep stays. We don't
+        // separately depend on OCCTSwiftIO because:
+        //   1. ScriptHarness / DrawingComposer libraries already don't pull
+        //      Viewport (target deps explicit; only `occtkit` does, via
+        //      RenderPreview), so the "drop Viewport from non-render
+        //      targets" story is already realized for library consumers.
+        //   2. OCCTSwiftIO's ScriptManifest is missing the `graphs` field
+        //      our local Sources/ScriptHarness/Manifest.swift carries — the
+        //      topology-graph descriptors that ScriptContext.addGraph() and
+        //      addGraphsForAllShapes() emit. Swapping would silently lose
+        //      that metadata for downstream OCCTSwiftViewport ScriptWatcher
+        //      consumers.
+        // If a future verb wants progress-aware STEP loading via
+        // OCCTSwiftIO's ShapeLoader.load(from:format:progress:), add the dep
+        // then.
+        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "0.6.0"),
         // OCCTSwiftAIS: high-level interactive services. Used here for the
         // headless-friendly subset only — Trihedron / WorkPlane / Axis /
         // PointCloud scene objects (each emits ViewportBody arrays via


### PR DESCRIPTION
Closes #42.

## Choosing Option A (bump-only)

The issue described two paths — **A** (bump Tools floor only) and **B** (also drop Viewport from non-render targets via OCCTSwiftIO imports). Option A applies cleanly here; Option B is moot for this package shape:

### Library targets already don't pull Viewport

`ScriptHarness` and `DrawingComposer` declare only `OCCTSwift` as a target dep. Only the `occtkit` executable pulls Viewport, and it does so through `RenderPreview`'s legitimate use of `CADFileLoader.shapeToBodyAndMetadata` — the bridge layer that Tools v0.6.0 still hosts. The 'drop Viewport from non-render targets' goal is already realized for library consumers.

### OCCTSwiftIO's ScriptManifest doesn't carry our `graphs` field

OCCTSwiftIO v0.1.0 ships a `ScriptManifest` that's pure-data, but its shape diverges from our local `Sources/ScriptHarness/Manifest.swift`:

| Field | Local (ScriptHarness) | OCCTSwiftIO |
|---|---|---|
| `graphs: [GraphDescriptor]?` | ✅ present | ❌ missing |
| `BodyDescriptor` placement | top-level | nested |
| `BodyDescriptor.color` | top-level `[Float]?` | computed `SIMD4<Float>?` from a private `colorArray` |

Switching to OCCTSwiftIO's manifest would silently lose the topology-graph descriptors that `ScriptContext.addGraph()` and `addGraphsForAllShapes()` emit. Downstream OCCTSwiftViewport's `ScriptWatcher` reads the `graphs` array — would break for the graph-export workflows.

If a future verb wants progress-aware STEP loading via OCCTSwiftIO's `ShapeLoader.load(from:format:progress:)`, the right move is to add OCCTSwiftIO as a direct dep at that point. Today no verb needs it.

## Verification

- `Package.swift` floor bumped: `OCCTSwiftTools from: "0.4.1"` → `from: "0.6.0"`. Verbose comment block in the manifest documents why we declined Option B.
- Resolution: OCCTSwiftTools v0.6.0, OCCTSwift transitively to v0.170.1 (still within our `from: "0.165.0"` floor), OCCTSwiftIO v0.1.0 picked up transitively (Tools 0.6.0 depends on it).
- `swift build` clean.
- Smoke verified against the v0.6.0 sheet-metal bracket (regenerated this run):
  - `compose-sheet-metal` writes `bracket.brep` cleanly.
  - `render-preview --camera iso`: **42090 bytes** — byte-identical to every prior version going back to v0.6.0. Confirms Tools v0.6.0's `CADFileLoader.shapeToBodyAndMetadata` API is unchanged.
  - `render-preview --show-axes --show-workplane xy --highlight face[2]`: 61595 bytes — Phase 2 overlays still working.

## Acceptance against #42

- [x] `Package.swift` floor bumped to Tools `0.6.0`.
- [x] (Optional) Decided NOT to switch non-render targets to `OCCTSwiftIO` import — explained why above.
- [x] `swift build` clean. (No tests in this package.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)