### PR TITLE
chore: bump OCCTSwift to 1.0.1 + cohort to 1.0.0 — v1.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9fcef339be64008d38393e50e167b22041b790e7759011d059c7646ee64ef8da",
+  "originHash" : "7ea3fd153b91822fbe37fd2581ff4563c89173a9a26d7ea7da0654ad9ef37184",
   "pins" : [
     {
       "identity" : "occtswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "c37fcff1b99f557f2572b209964abee699a2b7cc",
-        "version" : "0.170.1"
+        "revision" : "27ec6a6f12b512bf7c6fbdced084470f4b2d7b44",
+        "version" : "1.0.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftAIS.git",
       "state" : {
-        "revision" : "b906f7487246dd59a6243b28efbbd47704e9908d",
-        "version" : "0.6.0"
+        "revision" : "1c18da5d5fd4e42fe7637d9be10d75d1804167f6",
+        "version" : "1.0.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftIO.git",
       "state" : {
-        "revision" : "1905299e476e5fbe19ec927aa44565cc59efc09a",
-        "version" : "0.1.0"
+        "revision" : "ef7a4ad2d9c057968cda24f08122534e54980f50",
+        "version" : "1.0.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftMesh.git",
       "state" : {
-        "revision" : "ceb6b91cec80a2988fd5ef08f908e379d4179ac3",
-        "version" : "0.1.0"
+        "revision" : "01bd6b1abce612de78081e0875e05beaaf4bfbe6",
+        "version" : "1.0.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftTools.git",
       "state" : {
-        "revision" : "5e6dca35801966f7efc399c734a9d9739e48ec70",
-        "version" : "0.6.0"
+        "revision" : "4a082ee3af755cd60e159a9b82f214ee5239dd8c",
+        "version" : "1.0.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
       "state" : {
-        "revision" : "88c6f80abf66363afd1c4ea4f1e4de0b5eab6e25",
-        "version" : "0.55.0"
+        "revision" : "aaea62742ed6ae4e075e582c49292f397613c649",
+        "version" : "0.55.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,54 +21,45 @@ let package = Package(
         ),
     ],
     dependencies: [
-        // OCCTSwift v0.157+ pins to OCCT 8.0.0 beta1 (xcframework rebuilt against
-        // V8_0_0_beta1; internal BRepGraph bridge migrations to EditorView /
-        // NCollection_DynamicArray; Swift public API unchanged). Floor is
-        // v0.165.0 — earlier v0.157-v0.164 had a broken Package.swift binary
-        // target URL still pointing at the rc-era v0.131.0 xcframework
-        // (OCCTSwift#97), so remote SPM consumers couldn't compile against
-        // those tags. Soak window per OCCTSwiftScripts#36; bump to from: "1.0.0"
-        // when OCCT 8.0.0 GA tags on 2026-05-07.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.165.0"),
-        // OCCTSwiftViewport v0.55.0+ no longer ships OCCTSwiftTools as a
-        // sub-product — that bridge layer was split into its own repo to
-        // share with OCCTSwiftAIS (a sibling toolkit). We declare both as
-        // direct deps below.
-        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "0.55.0"),
-        // OCCTSwiftTools v0.6.0 split file-I/O off into a sibling repo
-        // (OCCTSwiftIO) so headless consumers don't drag in Viewport just to
-        // load a STEP file. We only use Tools for the bridge-layer
-        // CADFileLoader.shapeToBodyAndMetadata in RenderPreview, which
-        // legitimately needs Viewport, so the Tools dep stays. We don't
-        // separately depend on OCCTSwiftIO because:
-        //   1. ScriptHarness / DrawingComposer libraries already don't pull
-        //      Viewport (target deps explicit; only `occtkit` does, via
-        //      RenderPreview), so the "drop Viewport from non-render
-        //      targets" story is already realized for library consumers.
-        //   2. OCCTSwiftIO's ScriptManifest is missing the `graphs` field
-        //      our local Sources/ScriptHarness/Manifest.swift carries — the
-        //      topology-graph descriptors that ScriptContext.addGraph() and
-        //      addGraphsForAllShapes() emit. Swapping would silently lose
-        //      that metadata for downstream OCCTSwiftViewport ScriptWatcher
-        //      consumers.
+        // OCCTSwift v1.0.0 pins to OCCT 8.0.0 GA (2026-05-07). v1.0.1 ships
+        // the TopologyGraph.NodeKind fix (Product/Occurrence raw values were
+        // missing, so rootNodes silently returned [] for any graph with
+        // assembly roots). SemVer-stable from this floor.
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.1"),
+        // OCCTSwiftViewport stays at 0.55.x — no v1.0 yet. Floor 0.55.1
+        // matches OCCTSwiftAIS v1.0.0's required `body.triangleStyles` /
+        // `TriangleStyle` symbols (renderer-backed highlight overlay).
+        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "0.55.1"),
+        // OCCTSwiftTools v1.0.0 graduated alongside OCCTSwift v1.0.0. We use
+        // Tools for the bridge-layer CADFileLoader.shapeToBodyAndMetadata in
+        // RenderPreview, which legitimately needs Viewport, so the Tools dep
+        // stays. We don't separately depend on OCCTSwiftIO because
+        // OCCTSwiftIO's ScriptManifest is missing the `graphs` field our
+        // local Sources/ScriptHarness/Manifest.swift carries — the
+        // topology-graph descriptors that ScriptContext.addGraph() and
+        // addGraphsForAllShapes() emit. Swapping would silently lose that
+        // metadata for downstream OCCTSwiftViewport ScriptWatcher consumers.
         // If a future verb wants progress-aware STEP loading via
         // OCCTSwiftIO's ShapeLoader.load(from:format:progress:), add the dep
         // then.
-        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "0.6.0"),
-        // OCCTSwiftAIS: high-level interactive services. Used here for the
-        // headless-friendly subset only — Trihedron / WorkPlane / Axis /
-        // PointCloud scene objects (each emits ViewportBody arrays via
-        // makeBodies()) and the SubShape ↔ ViewportBody plumbing for
+        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.0.0"),
+        // OCCTSwiftAIS v1.0.0 graduated alongside OCCTSwift v1.0.0. Used
+        // here for the headless-friendly subset only — Trihedron / WorkPlane
+        // / Axis / PointCloud scene objects (each emits ViewportBody arrays
+        // via makeBodies()) and the SubShape ↔ ViewportBody plumbing for
         // highlight overlays. Selection / Manipulator / SwiftUI surfaces
-        // aren't relevant to a CLI; Dimension overlays render via a
-        // SwiftUI Canvas inside MetalViewportView and so don't reach
-        // OffscreenRenderer (filed upstream — see CLAUDE.md).
-        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "0.3.0"),
-        // OCCTSwiftMesh: mesh-domain algorithms (decimation today; smoothing /
-        // repair / remeshing in future releases). Vendors meshoptimizer
-        // (BSD-2-Clause / MIT-equivalent) inside an LGPL-2.1 wrapper. Powers
+        // aren't relevant to a CLI; Dimension overlays render via a SwiftUI
+        // Canvas inside MetalViewportView and so don't reach OffscreenRenderer.
+        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.0"),
+        // OCCTSwiftMesh v1.0.0 graduated alongside OCCTSwift v1.0.0. Powers
         // the `simplify-mesh` verb.
-        .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "0.1.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
+        // OCCTSwiftIO v1.0.0 graduated alongside OCCTSwift v1.0.0. Provides
+        // TopologyGraph.exportForML / exportJSON via extension after OCCTSwift
+        // v0.171.0 hoisted them out of the kernel. Pulled into GraphML and
+        // graphml verbs only — the rest of the package keeps its existing
+        // ScriptManifest type (with the `graphs` field) from ScriptHarness.
+        .package(url: "https://github.com/gsdali/OCCTSwiftIO.git", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -139,6 +130,7 @@ let package = Package(
             dependencies: [
                 "ScriptHarness",
                 .product(name: "OCCTSwift", package: "OCCTSwift"),
+                .product(name: "OCCTSwiftIO", package: "OCCTSwiftIO"),
             ],
             path: "Sources/GraphML",
             swiftSettings: [.swiftLanguageMode(.v6)]
@@ -170,6 +162,7 @@ let package = Package(
                 .product(name: "OCCTSwiftTools", package: "OCCTSwiftTools"),
                 .product(name: "OCCTSwiftAIS", package: "OCCTSwiftAIS"),
                 .product(name: "OCCTSwiftMesh", package: "OCCTSwiftMesh"),
+                .product(name: "OCCTSwiftIO", package: "OCCTSwiftIO"),
             ],
             path: "Sources/occtkit",
             swiftSettings: [.swiftLanguageMode(.v6)]

--- a/Sources/GraphML/main.swift
+++ b/Sources/GraphML/main.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import OCCTSwift
+import OCCTSwiftIO  // TopologyGraph.exportForML / GraphExport extension (v0.171.0+)
 import ScriptHarness
 
 struct MLExport: Codable {

--- a/Sources/ScriptHarness/BREPGraphJSONExporter.swift
+++ b/Sources/ScriptHarness/BREPGraphJSONExporter.swift
@@ -325,8 +325,7 @@ public enum BREPGraphJSONExporter {
             occurrences.append(OccurrenceEntry(
                 index: i,
                 productIndex: g.occurrenceProduct(i),
-                parentProductIndex: g.occurrenceParentProduct(i),
-                parentOccurrenceIndex: g.occurrenceParentOccurrence(i)
+                parentProductIndex: g.occurrenceParentProduct(i)
             ))
         }
 
@@ -350,6 +349,8 @@ public enum BREPGraphJSONExporter {
         case .compound: return "compound"
         case .compSolid: return "compSolid"
         case .coedge: return "coedge"
+        case .product: return "product"
+        case .occurrence: return "occurrence"
         }
     }
 }
@@ -543,5 +544,7 @@ struct ProductEntry: Codable {
 struct OccurrenceEntry: Codable {
     let index: Int
     let productIndex, parentProductIndex: Int
-    let parentOccurrenceIndex: Int?
+    // OCCT 8.0.0 reshaped assembly topology to Product → Occurrence → Product,
+    // so an occurrence has only one parent (a product). The old
+    // parentOccurrenceIndex field was removed in v1.0.0.
 }

--- a/Sources/ScriptHarness/BREPGraphSQLiteExporter.swift
+++ b/Sources/ScriptHarness/BREPGraphSQLiteExporter.swift
@@ -237,8 +237,10 @@ public enum BREPGraphSQLiteExporter {
         CREATE TABLE occurrences (
             idx                     INTEGER PRIMARY KEY,
             product_idx             INTEGER NOT NULL,
-            parent_product_idx      INTEGER NOT NULL,
-            parent_occurrence_idx   INTEGER
+            parent_product_idx      INTEGER NOT NULL
+            -- OCCT 8.0.0 reshaped assembly topology to Product → Occurrence →
+            -- Product, so an occurrence has only one parent (a product); the
+            -- old parent_occurrence_idx column was removed in v1.0.0.
         );
 
         CREATE TABLE root_products (
@@ -784,11 +786,9 @@ public enum BREPGraphSQLiteExporter {
         }
 
         for i in 0..<g.occurrenceCount {
-            let parentOcc = g.occurrenceParentOccurrence(i)
-            let parentOccStr = parentOcc.map { "\($0)" } ?? "NULL"
             try exec(db, """
-                INSERT INTO occurrences (idx, product_idx, parent_product_idx, parent_occurrence_idx)
-                VALUES (\(i), \(g.occurrenceProduct(i)), \(g.occurrenceParentProduct(i)), \(parentOccStr))
+                INSERT INTO occurrences (idx, product_idx, parent_product_idx)
+                VALUES (\(i), \(g.occurrenceProduct(i)), \(g.occurrenceParentProduct(i)))
                 """)
         }
 

--- a/Sources/occtkit/Commands/GraphML.swift
+++ b/Sources/occtkit/Commands/GraphML.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OCCTSwift
+import OCCTSwiftIO  // TopologyGraph.exportForML / GraphExport extension (v0.171.0+)
 import ScriptHarness
 
 enum GraphMLCommand: Subcommand {


### PR DESCRIPTION
Pure dep bump + GA migration fixes to graduate alongside the OCCTSwift v1.0.0 / OCCT 8.0.0 GA cohort.

## Dep bumps

- [OCCTSwift](https://github.com/gsdali/OCCTSwift/releases/tag/v1.0.0) 0.165.0 → 1.0.1
- OCCTSwiftViewport 0.55.0 → 0.55.1 (matches AIS v1.0.0's expected `TriangleStyle` / `body.triangleStyles` symbols)
- [OCCTSwiftTools](https://github.com/gsdali/OCCTSwiftTools/releases/tag/v1.0.0) 0.6.0 → 1.0.0
- [OCCTSwiftAIS](https://github.com/gsdali/OCCTSwiftAIS/releases/tag/v1.0.0) 0.3.0 → 1.0.0
- [OCCTSwiftMesh](https://github.com/gsdali/OCCTSwiftMesh/releases/tag/v1.0.0) 0.1.0 → 1.0.0
- [OCCTSwiftIO](https://github.com/gsdali/OCCTSwiftIO/releases/tag/v1.0.0) **new direct dep** — `GraphML` / `occtkit graphml` verb need the `TopologyGraph.exportForML` extension after the v0.171.0 hoist

## GA migration fixes (OCCTSwift v1.0.0 breaking changes absorbed)

- `BREPGraphJSONExporter` / `BREPGraphSQLiteExporter`: drop `parentOccurrenceIndex` field and `parent_occurrence_idx` column. OCCT 8.0 GA reshaped assembly topology to `Product → Occurrence → Product`, so an occurrence has only one parent (a product); `occurrenceParentOccurrence(_:)` was removed in v1.0.0.
- `BREPGraphJSONExporter.nodeKindName`: extend exhaustive switch with `.product` / `.occurrence` cases (`NodeKind` enum extended in v1.0.1 to cover the full `BRepGraph_NodeId::Kind` range).
- `GraphML` / `occtkit graphml`: add `import OCCTSwiftIO` for the `TopologyGraph.exportForML` extension.

## Validation

`swift build` clean (build complete, 71/71). No test target in this repo. `occtkit --help` smoke-runs OK.

Closes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
