### PR TITLE
chore: bump cohort floors (cosmetic; matches resolved-forward versions)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,12 +25,11 @@ let package = Package(
         // the TopologyGraph.NodeKind fix (Product/Occurrence raw values were
         // missing, so rootNodes silently returned [] for any graph with
         // assembly roots). SemVer-stable from this floor.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.1"),
-        // OCCTSwiftViewport graduated to v1.0.0 on 2026-05-08, one day after
-        // the rest of the cohort, with v1.0.1 the day after. The 1.0.0 floor
-        // is unblocked by OCCTSwiftTools v1.0.2, which widened its own
-        // Viewport constraint. Closes #45.
-        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.3"),
+        // OCCTSwiftViewport graduated to v1.0.0 on 2026-05-08 with v1.0.1
+        // the day after. The cohort floor is unblocked by OCCTSwiftTools
+        // v1.0.2, which widened its own Viewport constraint. Closes #45.
+        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.1"),
         // OCCTSwiftTools v1.0.0 graduated alongside OCCTSwift v1.0.0. We use
         // Tools for the bridge-layer CADFileLoader.shapeToBodyAndMetadata in
         // RenderPreview, which legitimately needs Viewport, so the Tools dep
@@ -43,7 +42,7 @@ let package = Package(
         // If a future verb wants progress-aware STEP loading via
         // OCCTSwiftIO's ShapeLoader.load(from:format:progress:), add the dep
         // then.
-        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.0.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.0.2"),
         // OCCTSwiftAIS v1.0.0 graduated alongside OCCTSwift v1.0.0. Used
         // here for the headless-friendly subset only — Trihedron / WorkPlane
         // / Axis / PointCloud scene objects (each emits ViewportBody arrays


### PR DESCRIPTION
Cosmetic floor bumps so declared intent matches actual resolved versions:

- OCCTSwift 1.0.1 → 1.0.3 (latest patch with #165 history APIs)
- OCCTSwiftViewport 1.0.0 → 1.0.1 (latest Viewport patch)
- OCCTSwiftTools 1.0.0 → 1.0.2 (latest Tools patch riding Viewport 1.0.1)

All three already resolved forward to these versions under SemVer's `from:` semantics; this just makes the manifest match.

`swift build` clean. No public API changes; no test target in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)