### PR TITLE
chore(deps): align cohort floors to crash-fixed Viewport 1.0.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5ee4d2699da4c1f666d10f7e3b90d6c1435708a072b56f21f8164f9fdca14355",
+  "originHash" : "5466b5b6fa17a7249a9c7a50523a182d244b9992049801b95e4da03e2e7a7a44",
   "pins" : [
     {
       "identity" : "occtswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "c479b1e7f74b701600bdb8e469a30d9f19973bdd",
-        "version" : "1.0.3"
+        "revision" : "2124f0c63ed5750886b9235838cd3b866d3367ee",
+        "version" : "1.1.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftAIS.git",
       "state" : {
-        "revision" : "1c18da5d5fd4e42fe7637d9be10d75d1804167f6",
-        "version" : "1.0.0"
+        "revision" : "dcb814b6332706d40717f66c6f327698283b59cf",
+        "version" : "1.0.2"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftTools.git",
       "state" : {
-        "revision" : "25156dc789dc58be930c333e8c34f7bbdd7414a3",
-        "version" : "1.0.2"
+        "revision" : "d71764d0468069369e71ee18e52c95e26a7aae0a",
+        "version" : "1.1.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
       "state" : {
-        "revision" : "fcd58157c6b0c58702e84def44bb6cf730927bb8",
-        "version" : "1.0.1"
+        "revision" : "6c8e95e62e2b25666ba9160af24bce22c7ccb08c",
+        "version" : "1.0.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,10 +26,11 @@ let package = Package(
         // missing, so rootNodes silently returned [] for any graph with
         // assembly roots). SemVer-stable from this floor.
         .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.3"),
-        // OCCTSwiftViewport graduated to v1.0.0 on 2026-05-08 with v1.0.1
-        // the day after. The cohort floor is unblocked by OCCTSwiftTools
-        // v1.0.2, which widened its own Viewport constraint. Closes #45.
-        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.1"),
+        // RenderPreview rasterizes through Viewport's OffscreenRenderer.
+        // Floored at v1.0.4: v1.0.3 fixes an uncatchable quantize() crash on
+        // body load (Viewport #30) and v1.0.4 makes the published Viewport
+        // package dependency-free (broke the Viewport↔Tools cycle).
+        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.4"),
         // OCCTSwiftTools v1.0.0 graduated alongside OCCTSwift v1.0.0. We use
         // Tools for the bridge-layer CADFileLoader.shapeToBodyAndMetadata in
         // RenderPreview, which legitimately needs Viewport, so the Tools dep
@@ -42,7 +43,7 @@ let package = Package(
         // If a future verb wants progress-aware STEP loading via
         // OCCTSwiftIO's ShapeLoader.load(from:format:progress:), add the dep
         // then.
-        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.0.2"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.1"),
         // OCCTSwiftAIS v1.0.0 graduated alongside OCCTSwift v1.0.0. Used
         // here for the headless-friendly subset only — Trihedron / WorkPlane
         // / Axis / PointCloud scene objects (each emits ViewportBody arrays
@@ -50,7 +51,7 @@ let package = Package(
         // highlight overlays. Selection / Manipulator / SwiftUI surfaces
         // aren't relevant to a CLI; Dimension overlays render via a SwiftUI
         // Canvas inside MetalViewportView and so don't reach OffscreenRenderer.
-        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.2"),
         // OCCTSwiftMesh v1.0.0 graduated alongside OCCTSwift v1.0.0. Powers
         // the `simplify-mesh` verb.
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),


### PR DESCRIPTION
Aligns Scripts to the crash-fixed cohort: `OCCTSwiftViewport` `1.0.1 → 1.0.4`, `OCCTSwiftTools` `1.0.2 → 1.1.1`, `OCCTSwiftAIS` `1.0.0 → 1.0.2`. Render-preview now hard-requires the fixed Viewport (uncatchable `quantize()` crash #30 + cycle fix). Pure dep-floor alignment; `occtkit` builds and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
