### PR TITLE
feat(package): declare iOS platform support (closes #52)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,16 @@ import PackageDescription
 let package = Package(
     name: "OCCTSwiftScripts",
     platforms: [
-        .macOS(.v15)
+        .macOS(.v15),
+        // iOS so the library products (DrawingComposer, ScriptHarness) link
+        // into downstream iOS apps (e.g. OCCTSwiftPartsAgent's SwiftUI app).
+        // Floored at v18 to match the sibling cohort (Viewport/Tools/AIS
+        // are .iOS(.v18)); OCCTSwift itself only needs v15. The executable
+        // targets (occtkit, Script, the legacy Graph* tools) shell out via
+        // Foundation.Process and aren't iOS-buildable, but SPM only compiles
+        // a target when something reachable requires it — an iOS app linking
+        // a library product never pulls the executables in. See #52.
+        .iOS(.v18)
     ],
     products: [
         .library(

--- a/Sources/ScriptHarness/ScriptContext.swift
+++ b/Sources/ScriptHarness/ScriptContext.swift
@@ -45,6 +45,8 @@ public final class ScriptContext: Sendable {
     public let metadata: ManifestMetadata?
 
     public init(exportSTEP: Bool = true, metadata: ManifestMetadata? = nil) {
+        let dir: URL
+        #if os(macOS)
         let home = FileManager.default.homeDirectoryForCurrentUser
 
         // Prefer iCloud Drive for cross-device sync (Mac → iPhone)
@@ -53,12 +55,20 @@ public final class ScriptContext: Sendable {
             .appendingPathComponent("OCCTSwiftScripts/output")
         let localDir = home.appendingPathComponent(".occtswift-scripts/output")
 
-        let dir: URL
         if FileManager.default.fileExists(atPath: iCloudDir.deletingLastPathComponent().deletingLastPathComponent().path) {
             dir = iCloudDir
         } else {
             dir = localDir
         }
+        #else
+        // iOS/sandboxed platforms: homeDirectoryForCurrentUser and the
+        // ~/Library/Mobile Documents iCloud path are unavailable. Write into
+        // the app sandbox's Documents directory, which is the iCloud-syncable
+        // location on iOS when the app declares a ubiquity container.
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        dir = documents.appendingPathComponent("OCCTSwiftScripts/output")
+        #endif
         self.outputDir = dir
         self.exportSTEP = exportSTEP
         self.metadata = metadata


### PR DESCRIPTION
## Summary
Adds `.iOS(.v18)` to the package `platforms` so the library products (`DrawingComposer`, `ScriptHarness`) link into downstream iOS apps (e.g. OCCTSwiftPartsAgent's SwiftUI app deploying to iPhone). Without an explicit iOS minimum, SPM assumed iOS 12 for these targets and any iOS app pulling them failed resolution against OCCTSwift's iOS-15 floor. v18 matches the sibling cohort (Viewport/Tools/AIS are `.iOS(.v18)`).

Closes #52.

## The non-obvious bit
Declaring iOS surfaced a macOS-only API in `ScriptContext`: `FileManager.homeDirectoryForCurrentUser` is unavailable on iOS, and the `~/Library/Mobile Documents/...` iCloud path doesn't exist in the iOS sandbox. The output-directory selection is now guarded per platform:
- **macOS** — unchanged (iCloud Drive if present, else `~/.occtswift-scripts/output`).
- **iOS** — writes into the app sandbox's Documents directory (the iCloud-syncable location when the app declares a ubiquity container).

The executable targets (`occtkit`, `Script`, legacy `Graph*`) shell out via `Foundation.Process` and aren't iOS-buildable, but SPM only compiles a target when something reachable requires it — an iOS app linking a library product never pulls them in, so no guards were needed there.

## Verification
- `xcodebuild -scheme DrawingComposer -destination 'generic/platform=iOS' build` → **BUILD SUCCEEDED** (arm64-apple-ios18.0, linking OCCTSwift's iOS slice)
- `xcodebuild -scheme ScriptHarness -destination 'generic/platform=iOS' build` → **BUILD SUCCEEDED**
- `swift build` (macOS) → **Build complete**, all executables still link

## Follow-up
A patch release after merge would let downstream consumers move their pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)