### PR TITLE
docs: context7 documentation + config (closes #63)

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
   "projectTitle": "OCCTSwiftScripts",
-  "description": "A script harness + headless CLI for OpenCASCADE CAD in Swift — the OCCTSwift answer to CadQuery / OpenSCAD. Edit a Swift script against the full OCCTSwift API, run it, see geometry live in OCCTSwiftViewport. Bundles the multi-call `occtkit` binary: 29 verbs for the topology graph, ISO technical drawings, reconstruction, sheet metal, construction (transform / boolean / pattern), introspection & measurement, mesh, render, STEP/IGES/STL I/O, and XCAF assemblies — each with flag-form, JSON-form, and a JSONL `--serve` mode for OCCTMCP and other consumers.",
+  "description": "A script harness + 29-verb `occtkit` CLI for OpenCASCADE CAD in Swift — the OCCTSwift answer to CadQuery/OpenSCAD. Ships the ScriptHarness and DrawingComposer libraries; OCCTMCP-ready.",
   "folders": [
     "docs",
     "Sources/ScriptHarness",
@@ -10,21 +10,23 @@
     "recipes"
   ],
   "excludeFolders": [
-    "docs/knowledge",
     "Tests",
-    "Scripts",
     ".build",
-    ".swiftpm"
+    "okf",
+    "Scripts",
+    ".swiftpm",
+    "docs/knowledge"
   ],
   "rules": [
-    "OCCTSwiftScripts is a CadQuery/OpenSCAD-style harness for OCCTSwift, not a CAD kernel itself — geometry comes from the OCCTSwift API (`import OCCTSwift`). The script accumulates bodies in a `ScriptContext` and calls `emit()`; the OCCTSwiftViewport demo app's file watcher live-reloads the result.",
-    "The script entry point is `Sources/Script/main.swift`. Iterate with `swift build` then `swift run Script`. A script always: `let ctx = ScriptContext()`, build geometry, `try ctx.add(shape, id:, color:, name:)` per body, then `try ctx.emit(description:)`.",
-    "Fallible OCCTSwift factories return optionals — unwrap with `guard let` / `if let` or a trailing `!` only in throwaway scripts; never assume success. `ScriptContext.add()` accepts `Shape`, `Wire`, or `Edge`.",
-    "Colors are `ScriptContext.Colors` constants (`.steel`, `.brass`, `.copper`, `.red`, …), passed as the `color:` argument; they are `[Float]` RGBA under the hood.",
-    "BREP is the primary output format (~1ms/body); a combined `output.step` is optional. Output lands in iCloud Drive `~/Library/Mobile Documents/com~apple~CloudDocs/OCCTSwiftScripts/output/` if present, else `~/.occtswift-scripts/output/`; `manifest.json` is written last so a partial failure leaves the prior frame intact.",
-    "`occtkit` is a busybox-style multi-call binary: run a verb as `occtkit <verb> ...`, `swift run occtkit <verb> ...`, or via an installed symlink (`make install`). 29 verbs cover graph / drawings / reconstruct / sheet-metal / construction / introspection / mesh / render / I/O / XCAF.",
-    "Every occtkit verb accepts flag-form OR JSON-form input (JSON on stdin or a file-path argv), plus a generic `--serve` mode that reads JSONL `{\"args\":[...]}` requests and emits one JSONL envelope per request (`{\"ok\":bool,\"exit\":int,\"stdout\":str,\"stderr\":str,\"error\":str?}`) — this is how OCCTMCP drives it. Verbs throw rather than `exit()` so `--serve` can recover.",
-    "Per-verb standalone executables (`OCCTRunner`, `GraphValidate`, …) are DEPRECATED — they print a stderr notice and will be removed; migrate to `occtkit <verb>`. 2D constraint solving (`solve-sketch`) was removed to keep the package free of closed-source deps.",
-    "Library products `ScriptHarness` (the `ScriptContext` output pipeline) and `DrawingComposer` (the multi-view ISO drawing orchestrator behind `drawing-export`) can be imported directly by downstream Swift packages without going through the CLI."
+    "OCCTSwiftScripts is a CadQuery/OpenSCAD-style harness for OCCTSwift, not a CAD kernel. Geometry comes from the OCCTSwift API (`import OCCTSwift`); a script accumulates bodies in a `ScriptContext`, calls `emit()`, and OCCTSwiftViewport live-reloads.",
+    "Script entry point is `Sources/Script/main.swift`; build then `swift run Script`. Always: `let ctx = ScriptContext()`, build geometry, `try ctx.add(shape, id:, color:)` per body, `try ctx.emit()` LAST. Headless: `occtkit run <file>.swift`.",
+    "Fallible OCCTSwift factories return optionals — unwrap with `guard let`/`if let`, or `!` only in throwaway scripts. `ScriptContext.add()` accepts `Shape`, `Wire`, or `Edge`; `addCompound([Shape])` and `addGraph(_:)` also exist.",
+    "Colors are `ScriptContext.Colors` constants (`.steel`, `.brass`, `.copper`, `.red`, ...), passed as the `color:` argument; they are `[Float]` RGBA under the hood.",
+    "Output: one `body-N.brep` per add + an optional combined `output.step`, to iCloud `.../CloudDocs/OCCTSwiftScripts/output/` if present, else `~/.occtswift-scripts/output/`. `manifest.json` is written LAST so a partial failure keeps the prior frame.",
+    "`occtkit` is a busybox-style multi-call binary: run a verb as `occtkit <verb> ...`, `swift run occtkit <verb> ...`, or an installed symlink (`make install`). 29 verbs span script-host, graph, drawings, reconstruct, construction, I/O, mesh, render, XCAF.",
+    "Every occtkit verb takes flag-form OR JSON-form input (JSON on stdin or a file-path argv), plus a `--serve` mode: a JSONL loop reading `{\"args\":[...]}` and emitting one `{ok,exit,stdout,stderr,error?}` envelope per request. OCCTMCP drives it this way.",
+    "Stable topology IDs use `face[N]`/`edge[N]`/`vertex[N]` (index in `Shape.faces()`/`.edges()`/`.vertices()` order), deterministic per BREP. IDs from `query-topology` feed `render-preview --highlight`, `feature-recognize` topologyRefs, and `graph-select`.",
+    "This repo OWNS `render-preview`: render a headless PNG with `render-preview <brep>... --output <png> [--camera iso|front|top|...] [--display-mode shaded|wireframe|...] [--highlight face[N]]`, wrapping OCCTSwiftViewport's OffscreenRenderer.",
+    "Library products `ScriptHarness` (the `ScriptContext` output pipeline) and `DrawingComposer` (`Composer.render(spec:shape:)`, the multi-view ISO drawing engine behind `drawing-export`) import directly into downstream Swift packages without the CLI."
   ]
 }

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -22,7 +22,7 @@ thereafter) without a C++ source build.
 ## Build
 
 ```bash
-git clone https://github.com/gsdali/OCCTSwiftScripts.git
+git clone https://github.com/SecondMouseAU/OCCTSwiftScripts.git
 cd OCCTSwiftScripts
 swift build                  # first build ~30s, incremental ~1-2s
 ```
@@ -56,7 +56,8 @@ swift run Script
 ```
 
 This writes one `body-N.brep` per `add()`, a combined `output.step`, and `manifest.json` (written
-last) to the output directory.
+last) to the output directory. To run an arbitrary `.swift` file headlessly (no editing of
+`Sources/Script/main.swift`), use `occtkit run my_script.swift`.
 
 ### Output location
 
@@ -100,13 +101,30 @@ make uninstall
 
 Every verb accepts **flag-form** or **JSON-form** input (JSON on stdin or as an argv path), plus a
 generic **`--serve`** mode that reads JSONL `{"args":[...]}` requests and writes one JSONL envelope
-per request — used by OCCTMCP and any other JSON-driven consumer. See
-[occtkit CLI basics](../guides/cookbook/occtkit-cli.md).
+per request — used by OCCTMCP and any other JSON-driven consumer.
+
+```bash
+# JSON-form on stdin
+echo '{"inputBrep":"part.brep","metrics":["volume","boundingBox"]}' | occtkit metrics
+
+# --serve: one envelope per request line
+printf '{"args":["a.brep"]}\n{"args":["b.brep"]}\n' | occtkit graph-validate --serve
+```
+
+### Render a preview (this repo owns `render-preview`)
+
+```bash
+occtkit render-preview part.brep --output part.png --camera iso --display-mode shaded-with-edges
+```
+
+<!-- 3D render TODO: render-preview output for part.png -->
 
 ---
 
 ## Next steps
 
+- **[occtkit verb reference](../reference/occtkit-verbs.md)** — all 29 verbs: purpose, flags, JSON I/O, runnable examples.
+- **[ScriptHarness API](../reference/ScriptHarness.md)** — the `ScriptContext` output pipeline, with runnable Swift snippets.
+- **[DrawingComposer API](../reference/DrawingComposer.md)** — the multi-view ISO drawing library behind `drawing-export`.
 - **[Cookbook](../guides/cookbook/)** — task-oriented recipes for authoring, drawings, measurement, reconstruction, and more.
-- **[Reference](../reference/)** — the `ScriptContext` API and every `occtkit` verb's flags, JSON schema, and example calls.
 - **[Architecture](architecture.md)** — the targets, the output pipeline, the `--serve` envelope, and the ecosystem.

--- a/docs/reference/DrawingComposer.md
+++ b/docs/reference/DrawingComposer.md
@@ -1,0 +1,245 @@
+---
+title: DrawingComposer API
+nav_order: 3
+parent: Reference
+---
+
+# `DrawingComposer` library reference
+
+`DrawingComposer` turns a `DrawingSpec` + a live `Shape` into a fully populated
+`DXFWriter` (a complete multi-view ISO technical drawing). It is the in-process library
+behind the `occtkit drawing-export` verb — for iOS apps and library consumers that can't
+subprocess. The CLI and the library run the **same** composition logic; the CLI only adds
+the BREP load and the DXF write.
+
+```swift
+.product(name: "DrawingComposer", package: "OCCTSwiftScripts"),
+```
+
+Source: [`Sources/DrawingComposer/`](https://github.com/SecondMouseAU/OCCTSwiftScripts/tree/main/Sources/DrawingComposer).
+
+---
+
+## `Composer.render`
+
+```swift
+public enum Composer {
+    /// Single-part multi-view drawing.
+    public static func render(spec: DrawingSpec, shape: Shape) throws -> DrawingComposerResult
+
+    /// General-arrangement (assembly) drawing from explicit components.
+    public static func render(spec: DrawingSpec,
+                              components: [DrawingComponent]) throws -> DrawingComposerResult
+
+    /// General-arrangement drawing from an XCAF assembly document
+    /// (flattened to positioned leaf parts; leaf names drive the parts list).
+    public static func render(spec: DrawingSpec, document: Document) throws -> DrawingComposerResult
+}
+```
+
+The caller writes the result with `try result.writer.write(to: url)`.
+
+### Single-part example
+
+```swift
+import OCCTSwift
+import DrawingComposer
+
+let shape = try Shape.loadBREP(fromPath: "part.brep")
+
+let spec = DrawingSpec(
+    sheet: SheetSpec(size: .a3, orientation: .landscape, projection: .third, scale: .auto),
+    title: TitleBlockSpec(title: "Bracket", drawingNumber: "DRW-001",
+                          material: "AlMg3", revision: "A"),
+    views: [ViewSpec(name: "front"), ViewSpec(name: "top"), ViewSpec(name: "right")],
+    dimensions: [
+        DimensionSpec(view: "front", type: .linear, from: [0, 0], to: [40, 0],
+                      offset: 10, label: "40")
+    ]
+)
+
+let result = try Composer.render(spec: spec, shape: shape)
+try result.writer.write(to: URL(fileURLWithPath: "bracket.dxf"))
+print(result.scaleLabel, result.viewCount, result.sectionCount, result.detailCount)
+```
+
+<!-- drawing-export TODO: embed bracket.dxf rendered to PNG -->
+
+### Assembly (general-arrangement) example
+
+```swift
+let result = try Composer.render(spec: spec, components: [
+    Composer.DrawingComponent(shape: housing, name: "Housing", partNumber: "P-001", material: "Cast iron"),
+    Composer.DrawingComponent(shape: shaft,   name: "Shaft",   partNumber: "P-002", material: "Steel",
+                              transform: [1,0,0,20, 0,1,0,0, 0,0,1,0])   // row-major 3×4 placement
+])
+try result.writer.write(to: URL(fileURLWithPath: "ga.dxf"))
+// → numbered balloons on the front view + a merged PARTS LIST (qty summed per partNumber/name)
+```
+
+---
+
+## `DrawingComposerResult`
+
+```swift
+public struct DrawingComposerResult: Sendable {
+    public let writer: DXFWriter
+    public let scaleLabel: String           // e.g. "1:2" (ISO 5455 snapped when scale == .auto)
+    public let viewCount: Int
+    public let sectionCount: Int
+    public let detailCount: Int
+    public let componentCount: Int          // 1 for single-shape; N for general-arrangement
+    public let partsList: [BillOfMaterials.Item]   // empty for single-shape
+}
+```
+
+---
+
+## `DrawingSpec` schema
+
+`DrawingSpec` is `Codable` — the same JSON the `drawing-export` verb reads. Source:
+[`Spec.swift`](https://github.com/SecondMouseAU/OCCTSwiftScripts/blob/main/Sources/DrawingComposer/Spec.swift).
+
+```swift
+public struct DrawingSpec: Codable, Sendable {
+    public var shape: String?              // path to BREP — CLI only (ignored by render(spec:shape:))
+    public var output: String?             // path for output DXF — CLI only
+    public var sheet: SheetSpec
+    public var title: TitleBlockSpec?      // omitted → no title block
+    public var views: [ViewSpec]           // typically 3 orthographic views
+    public var sections: [SectionSpec]?
+    public var centerlines: AutoToggle?    // .auto | .none (default .auto)
+    public var centermarks: CentermarkRequest?   // "auto" | "none" | [explicit]
+    public var cosmeticThreads: [CosmeticThreadSpec]?   // ISO 6410
+    public var surfaceFinish: [SurfaceFinishSpec]?      // ISO 1302
+    public var gdt: [GDTSpec]?             // ISO 1101 feature control frames
+    public var detailViews: [DetailViewSpec]?
+    public var dimensions: [DimensionSpec]?
+    public var deflection: Double?         // tessellation deflection (default 0.1)
+}
+```
+
+### Sheet
+
+```swift
+public struct SheetSpec: Codable, Sendable {
+    public var size: PaperSizeName          // a0 | a1 | a2 | a3 | a4
+    public var orientation: OrientationName // landscape | portrait
+    public var projection: ProjectionAngleName  // first | third
+    public var scale: ScaleSpec             // "auto" or "n:d" (e.g. "1:2")
+    public var border: Bool?
+    public var projectionSymbol: Bool?
+}
+```
+
+`ScaleSpec` decodes from a string: `"auto"` (ISO 5455 snapped to fit) or `"n:d"`.
+
+### Title block (ISO 7200)
+
+```swift
+public struct TitleBlockSpec: Codable, Sendable {
+    public var title: String
+    public var drawingNumber, owner, creator, approver, documentType: String?
+    public var dateOfIssue, revision, sheetNumber, language, material, weight: String?
+}
+```
+
+### Views, sections, details
+
+```swift
+public struct ViewSpec: Codable, Sendable {
+    public var name: String                 // "front" | "top" | "right" | ... (drives layout)
+    public var direction: [Double]?         // optional explicit projection direction
+}
+
+public struct SectionSpec: Codable, Sendable {
+    public var name: String
+    public var plane: PlaneSpec             // { origin: [x,y,z], normal: [x,y,z] }
+    public var labelOnView: String?         // parent view to draw the cutting-plane line on
+    public var viewDirection: [Double]?
+    public var hatchAngle: Double?          // radians, default π/4
+    public var hatchSpacing: Double?        // mm, default 3
+}
+
+public struct DetailViewSpec: Codable, Sendable {
+    public var name: String
+    public var fromView: String
+    public var centre: [Double]             // [x,y] in parent view space
+    public var radius: Double
+    public var scale: Double
+    public var placement: [Double]?         // [x,y] on the sheet
+}
+```
+
+### Annotations
+
+```swift
+public enum CentermarkRequest { case auto, off, explicit([CentermarkSpec]) }   // JSON: "auto"|"none"|[...]
+
+public struct CosmeticThreadSpec: Codable, Sendable {   // ISO 6410
+    public var view: String
+    public var axisStart, axisEnd: [Double]   // [x,y]
+    public var majorDiameter, pitch: Double
+    public var callout: String?
+}
+
+public struct SurfaceFinishSpec: Codable, Sendable {    // ISO 1302
+    public var view: String
+    public var position, leaderTo: [Double]   // [x,y]
+    public var ra: Double
+    public var symbol: String?   // any | machiningRequired | machiningProhibited
+    public var method: String?
+}
+
+public struct GDTSpec: Codable, Sendable {              // ISO 1101
+    public var view: String
+    public var position: [Double]             // [x,y]
+    public var symbol: String                 // perpendicularity | flatness | …
+    public var tolerance: String
+    public var datums: [String]?
+    public var leaderTo: [Double]?
+}
+```
+
+### Dimensions
+
+```swift
+public struct DimensionSpec: Codable, Sendable {
+    public var view: String
+    public var type: DimensionKind            // linear | radial | diameter | angular
+    // linear:   from, to ([x,y]); offset?
+    // radial/diameter: centre ([x,y]), radius; leaderAngle?
+    // angular:  vertex, ray1, ray2 ([x,y]); arcRadius?
+    public var from, to, centre, vertex, ray1, ray2: [Double]?
+    public var offset, radius, leaderAngle, arcRadius: Double?
+    public var label: String?
+}
+```
+
+---
+
+## Full JSON spec example (for `drawing-export`)
+
+```json
+{
+  "shape": "part.brep",
+  "output": "sheet.dxf",
+  "sheet": { "size": "a3", "orientation": "landscape", "projection": "third", "scale": "auto" },
+  "title": { "title": "Bracket", "drawingNumber": "DRW-001", "material": "AlMg3", "revision": "A" },
+  "views": [ { "name": "front" }, { "name": "top" }, { "name": "right" } ],
+  "sections": [
+    { "name": "A-A", "plane": { "origin": [0,0,0], "normal": [0,1,0] }, "labelOnView": "front" }
+  ],
+  "dimensions": [
+    { "view": "front", "type": "linear", "from": [0,0], "to": [40,0], "offset": 10, "label": "40" }
+  ]
+}
+```
+
+```bash
+echo '{ ... spec above ... }' | drawing-export
+# or
+drawing-export spec.json
+```
+
+<!-- drawing-export TODO: embed sheet.dxf rendered to PNG -->

--- a/docs/reference/ScriptHarness.md
+++ b/docs/reference/ScriptHarness.md
@@ -1,0 +1,228 @@
+---
+title: ScriptHarness API
+nav_order: 2
+parent: Reference
+---
+
+# `ScriptHarness` library reference
+
+`ScriptHarness` is the SPM library product behind the script workflow. Its core type,
+`ScriptContext`, accumulates geometry built with the **full OCCTSwift API**, writes each
+body as a BREP file, optionally writes a combined STEP, and emits a `manifest.json` that
+OCCTSwiftViewport's ScriptWatcher live-reloads.
+
+```swift
+.product(name: "ScriptHarness", package: "OCCTSwiftScripts"),
+```
+
+Source: [`Sources/ScriptHarness/`](https://github.com/SecondMouseAU/OCCTSwiftScripts/tree/main/Sources/ScriptHarness).
+
+---
+
+## `ScriptContext`
+
+```swift
+public final class ScriptContext: Sendable {
+    public let exportSTEP: Bool
+    public let metadata: ManifestMetadata?
+
+    public init(exportSTEP: Bool = true, metadata: ManifestMetadata? = nil)
+}
+```
+
+The init resolves the output directory (and **cleans** it):
+
+1. iCloud Drive — `~/Library/Mobile Documents/com~apple~CloudDocs/OCCTSwiftScripts/output/` if present, else
+2. Local — `~/.occtswift-scripts/output/`.
+
+(On iOS/sandboxed platforms it writes into the app's Documents directory.)
+
+### Minimal lifecycle
+
+A script always: make a context → build geometry → `add` each body → `emit` **last**.
+
+```swift
+import OCCTSwift
+import ScriptHarness
+
+let ctx = ScriptContext()
+let C = ScriptContext.Colors.self
+
+// Sketch a profile
+let profile = Wire.rectangle(width: 20, height: 10)!
+try ctx.add(profile, id: "sketch", color: C.yellow)
+
+// Extrude → fillet
+let solid = Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: 5)!
+let filleted = solid.filleted(radius: 1.0)!
+try ctx.add(filleted, id: "body", color: C.blue)
+
+// Boolean cut
+let hole = Shape.cylinder(radius: 3, height: 10)!.translated(by: SIMD3(5, 0, -1))!
+let result = filleted.subtracting(hole)!
+try ctx.add(result, id: "final", color: C.steel)
+
+try ctx.emit(description: "Filleted plate with hole")
+```
+
+Run it from a checkout with `swift run Script`, or run any `.swift` file headlessly with
+`occtkit run <file>.swift`.
+
+---
+
+## Adding geometry
+
+`ScriptContext.add` is overloaded for `Shape`, `Wire`, and `Edge`. Wire/edge inputs are
+converted to a `Shape` internally (BREP preserves the topology; the viewport draws them as
+wireframe). Each `add` writes `body-N.brep` immediately.
+
+```swift
+// Shape (solids, shells, compounds, faces)
+public func add(_ shape: Shape, id: String? = nil, color: [Float]? = nil,
+                name: String? = nil, roughness: Float? = nil, metallic: Float? = nil) throws
+
+// Wire (profiles, sketches, sweep paths)
+public func add(_ wire: Wire, id: String? = nil, color: [Float]? = nil, name: String? = nil) throws
+
+// Edge
+public func add(_ edge: Edge, id: String? = nil, color: [Float]? = nil, name: String? = nil) throws
+
+// Multiple shapes → one compound (assembly results)
+public func addCompound(_ shapes: [Shape], id: String? = nil,
+                        color: [Float]? = nil, name: String? = nil) throws
+```
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `id` | `String?` | Body identifier (default `"body-N"`) |
+| `color` | `[Float]?` | RGBA `[r,g,b,a]`, 0–1 |
+| `name` | `String?` | Display name |
+| `roughness` / `metallic` | `Float?` | PBR (reserved; Shape overload only) |
+
+```swift
+try ctx.add(shape, id: "part", color: C.steel, name: "Bracket")   // solid
+try ctx.add(wire,  id: "sketch", color: C.yellow)                  // wireframe
+try ctx.addCompound([a, b], id: "assembly", color: C.gray)         // compound
+```
+
+---
+
+## Topology graphs
+
+`ScriptContext` can also export topology graphs (JSON + optional SQLite) alongside bodies.
+These are consumed by `occtkit graph-query` and the viewport's graph tooling.
+
+```swift
+public func addGraph(_ graph: TopologyGraph, id: String? = nil,
+                     sourceBodyId: String? = nil, sqlite: Bool = true) throws
+
+/// Build + export a TopologyGraph for every shape added so far.
+public func addGraphsForAllShapes(sqlite: Bool = true) throws
+```
+
+```swift
+try ctx.add(part, id: "part")
+try ctx.addGraphsForAllShapes(sqlite: true)   // → graph-0.json + graph-0.sqlite
+try ctx.emit(description: "part + topology graph")
+```
+
+> `occtkit run <file>.swift --format graph-json,graph-sqlite` injects
+> `addGraphsForAllShapes(...)` for you, so plain scripts need not call it.
+
+---
+
+## Emit
+
+```swift
+public func emit(description: String? = nil) throws
+```
+
+Call **last**. It writes (in order): a combined `output.step` (only when `exportSTEP` and
+there are shapes), then `manifest.json` **last** — so a partial failure leaves the prior
+frame intact and the watcher only triggers on a complete frame.
+
+```swift
+let ctx = ScriptContext(exportSTEP: false)   // BREP only, faster (no STEP)
+// ... add bodies ...
+try ctx.emit(description: "My parametric design")
+```
+
+---
+
+## Predefined colors
+
+`ScriptContext.Colors` exposes `[Float]` RGBA constants:
+
+```swift
+let C = ScriptContext.Colors.self
+// .red .green .blue .yellow .orange .purple .cyan .white .gray .steel .brass .copper
+try ctx.add(shape, color: C.steel)
+```
+
+---
+
+## Manifest types
+
+`emit` serialises a `ScriptManifest`. These `Codable`/`Sendable` types are public, so
+in-process consumers can read or build manifests directly.
+
+```swift
+public struct ScriptManifest: Codable, Sendable {
+    public let version: Int            // default 1
+    public let timestamp: Date
+    public let description: String?
+    public let bodies: [BodyDescriptor]
+    public let graphs: [GraphDescriptor]?
+    public let metadata: ManifestMetadata?
+}
+
+public struct BodyDescriptor: Codable, Sendable {
+    public let id: String?
+    public let file: String            // e.g. "body-0.brep"
+    public let format: String          // "brep"
+    public let name: String?
+    public let color: [Float]?         // RGBA
+    public let roughness: Float?
+    public let metallic: Float?
+}
+
+public struct GraphDescriptor: Codable, Sendable {
+    public let id: String
+    public let file: String            // e.g. "graph-0.json"
+    public let sourceBodyId: String?
+    public let stats: GraphStats?      // faces/edges/vertices/shells/solids
+}
+
+public struct ManifestMetadata: Codable, Sendable {
+    public let name: String
+    public let revision: String?
+    public let dateCreated: Date?
+    public let dateModified: Date?
+    public let source: String?
+    public let tags: [String]?
+    public let notes: String?
+}
+```
+
+Attach part metadata at construction time:
+
+```swift
+let ctx = ScriptContext(metadata: ManifestMetadata(
+    name: "L-Bracket", revision: "A", source: "parametric script", tags: ["bracket", "demo"]
+))
+```
+
+---
+
+## Errors
+
+```swift
+public enum ScriptError: Error, LocalizedError {
+    case conversionFailed(String)   // e.g. Wire → Shape failed
+    case message(String)
+}
+```
+
+Fallible OCCTSwift factories return optionals — unwrap with `guard let`/`if let` in real
+code, or a trailing `!` only in throwaway scripts. `ScriptContext.add` throws
+`ScriptError.conversionFailed` when a Wire/Edge/compound conversion fails.

--- a/docs/reference/occtkit-verbs.md
+++ b/docs/reference/occtkit-verbs.md
@@ -1,0 +1,548 @@
+---
+title: occtkit verb reference
+nav_order: 1
+parent: Reference
+---
+
+# `occtkit` verb reference
+
+`occtkit` is a single multi-call (busybox-style) binary that bundles **29 headless
+verbs**. Every verb is grounded in a `Subcommand` type under
+[`Sources/occtkit/Commands/`](https://github.com/SecondMouseAU/OCCTSwiftScripts/tree/main/Sources/occtkit/Commands).
+This page documents each verb's purpose, its JSON / flag inputs, the JSON it writes
+to stdout, and a runnable CLI example.
+
+## Invocation styles
+
+A verb can be invoked four ways (all equivalent):
+
+```bash
+occtkit graph-validate body.brep              # umbrella binary + verb
+graph-validate body.brep                       # installed per-verb symlink (make install)
+swift run occtkit graph-validate body.brep     # from a checkout, no install
+```
+
+Every verb also accepts:
+
+- **Flag form** — positional paths + `--flags` as documented per verb below.
+- **JSON form** — a JSON request on **stdin**, or a `*.json` file path as the first argv.
+- **`--serve` mode** — a JSONL request loop: each stdin line is `{"args":[...]}` and
+  the response is one JSONL envelope per request:
+  `{"ok":bool,"exit":int,"stdout":str,"stderr":str,"error":str?}`. The subcommand's own
+  stdout/stderr (including child-process output) is captured *into* the envelope, not
+  leaked. This is how [OCCTMCP](https://github.com/SecondMouseAU/OCCTMCP) drives occtkit.
+
+```bash
+# --serve: one envelope per request line
+printf '{"args":["a.brep"]}\n{"args":["b.brep"]}\n' | occtkit graph-validate --serve
+```
+
+`occtkit --help` prints every verb with its one-line summary.
+
+> Stable topology IDs. Many verbs reference faces/edges/vertices by the canonical
+> `face[N]` / `edge[N]` / `vertex[N]` scheme, where `N` is the index in
+> `Shape.faces()` / `.edges()` / `.vertices()` iteration order. These indices are
+> deterministic for a given BREP file, so an ID returned by `query-topology` can be
+> fed straight into `render-preview --highlight` or `feature-recognize`'s `topologyRefs`.
+
+---
+
+## Verb index
+
+| Domain | Verbs |
+|---|---|
+| Script host | [`run`](#run) |
+| Topology graph | [`graph-validate`](#graph-validate), [`graph-compact`](#graph-compact), [`graph-dedup`](#graph-dedup), [`graph-query`](#graph-query), [`graph-ml`](#graph-ml), [`graph-select`](#graph-select) |
+| Introspection | [`feature-recognize`](#feature-recognize), [`metrics`](#metrics), [`query-topology`](#query-topology), [`measure-distance`](#measure-distance), [`measure-deviation`](#measure-deviation) |
+| Drawings & export | [`dxf-export`](#dxf-export), [`drawing-export`](#drawing-export) |
+| Composition | [`reconstruct`](#reconstruct), [`compose-sheet-metal`](#compose-sheet-metal) |
+| Construction | [`transform`](#transform), [`boolean`](#boolean), [`pattern`](#pattern) |
+| I/O | [`load-brep`](#load-brep), [`import`](#import) |
+| Engineering analysis | [`check-thickness`](#check-thickness), [`analyze-clearance`](#analyze-clearance), [`heal`](#heal) |
+| Mesh | [`mesh`](#mesh), [`simplify-mesh`](#simplify-mesh) |
+| Render | [`render-preview`](#render-preview) |
+| XCAF | [`inspect-assembly`](#inspect-assembly), [`set-metadata`](#set-metadata) |
+
+---
+
+## Script host
+
+### `run`
+
+Run an arbitrary user `.swift` file as an OCCTSwift script, via a cached SPM workspace
+under `~/.occtswift-scripts/runner-cache/workspace/`. The script links `ScriptHarness`
+(resolved as a path dep from `$OCCTKIT_SCRIPTS_PATH`, else auto-detected from the binary,
+else the published tag).
+
+**Flags:** `--format <list>` (any of `brep`, `step`, `graph-json`, `graph-sqlite`;
+default `brep,step`) · `--output, -o <dir>` (copy the output dir after the run).
+
+When `graph-json` / `graph-sqlite` are requested, `try ctx.addGraphsForAllShapes(...)`
+is injected before `emit`. When `step` is absent, `ScriptContext(exportSTEP: false)` is used.
+
+```bash
+occtkit run recipes/01-mounting-bracket/main.swift --format brep,graph-sqlite --output /tmp/out
+```
+
+---
+
+## Topology graph
+
+### `graph-validate`
+
+Validate a BREP's topology graph and surface a structured health record.
+
+**Input:** `graph-validate <shape.brep>`
+**Output:** `{ isValid, errorCount, warningCount, healthRecord }` where `healthRecord`
+carries `{ isValid, shapeType, freeEdgeCount, nakedVertexCount, smallEdgeCount,
+smallFaceCount, selfIntersecting, errors }` (populated from `Shape.analyze()`;
+`nakedVertexCount` is always `0` — OCCTSwift does not expose it).
+
+```bash
+graph-validate body.brep
+```
+
+### `graph-compact`
+
+Compact a graph (drop unreferenced nodes) and write a rebuilt BREP.
+
+**Input:** `graph-compact <in.brep> <out.brep>`
+**Output:** a compaction report `{ nodesBefore, ... , output }`.
+
+```bash
+graph-compact in.brep out.brep
+```
+
+### `graph-dedup`
+
+Deduplicate shared surface/curve geometry and write a rebuilt BREP.
+
+**Input:** `graph-dedup <in.brep> <out.brep>`
+**Output:** a dedup report including `output`.
+
+```bash
+graph-dedup in.brep out.brep
+```
+
+### `graph-query`
+
+Emit a JSON topology summary from a **BREPGraph SQLite** database (the `.sqlite` produced
+by `ScriptContext.addGraph(..., sqlite: true)` / `occtkit run --format graph-sqlite`).
+
+**Input:** `graph-query <graph.sqlite>`
+**Output:** `{ summary{solids,shells,faces,wires,edges,vertices,coedges,boundaryEdges,
+nonManifoldEdges,degenerateEdges,openShells}, counts{freeEdges,openWires,facesWithHoles},
+valence{face,vertex} }`.
+
+```bash
+graph-query graph.sqlite
+```
+
+### `graph-ml`
+
+Export the topology graph plus UV-grid face samples and edge-curve samples as
+ML-friendly JSON (UV-Net / B-rep GNN feature export, via `OCCTSwiftIO`).
+
+**Input:** `graph-ml <shape.brep> [--uv-samples N] [--edge-samples N]`
+(defaults: `--uv-samples 16`, `--edge-samples 32`).
+**Output:** `{ vertexPositions, edgeBoundaryFlags, edgeManifoldFlags, faceAdjacentFaces,
+faceToFace, faceToEdge, edgeToVertex, faces[], edges[], faceAdjacency[], sampling }` —
+COO adjacency matrices, per-face position/normal/curvature grids, and a convexity-attributed
+face-adjacency graph (`convexity` ∈ `convex|concave|smooth`).
+
+```bash
+graph-ml part.brep --uv-samples 16 --edge-samples 32 > part.json
+```
+
+### `graph-select`
+
+Direct B-rep graph adjacency / selection queries — the "pointer" primitive behind
+DSL selectors and B-rep GNN selection (no full graph export needed).
+
+**Input:** `graph-select <shape.brep> --query <type> [ids]`. Queries:
+`face-neighbors --face N` · `edge-faces --edge M` · `vertex-edges --vertex K` ·
+`face-adjacency` · `edges-class --class boundary|non-manifold|seam|degenerate`.
+Face indices follow `shape.faces()` order (AAG); edge/vertex indices are TopologyGraph indices.
+**Output:** per-query JSON tagged with `query`, e.g. `face-neighbors` returns
+`{ face, isPlanar, isVertical, isHorizontal, normal, neighbors[{face,convexity,sharedEdgeCount}] }`.
+
+```bash
+graph-select part.brep --query face-neighbors --face 0
+graph-select part.brep --query edges-class --class boundary
+```
+
+---
+
+## Introspection
+
+### `feature-recognize`
+
+Detect pockets and holes via AAG (Attributed Adjacency Graph) heuristics.
+
+**Input:** `feature-recognize <shape.brep>`
+**Output:** `{ pockets[], holes[], features[] }`. Each `features[]` entry has
+`{ id, kind ("pocket"|"hole"), confidence (1.0 — rule-based), params, topologyRefs }`,
+where `topologyRefs` use the `face[N]` scheme.
+
+```bash
+feature-recognize bracket.brep
+```
+
+### `metrics`
+
+Volume / surface area / centre of mass / bounding box / principal axes for a BREP.
+Pure read, no file output. `volume`, `centerOfMass`, `principalAxes` come from
+`Shape.volumeInertia` (solid-only; `null` otherwise).
+
+**Flag form:** `metrics <input.brep> [--metrics volume,surfaceArea,centerOfMass,boundingBox,boundingBoxOptimal,principalAxes]`
+(omit `--metrics` for all except `boundingBoxOptimal`, which is opt-in).
+**JSON form:** `{ "inputBrep": "...", "metrics": [...] }`
+**Output:** `{ volume?, surfaceArea?, centerOfMass?, boundingBox?, boundingBoxOptimal?, principalAxes? }`.
+
+```bash
+metrics part.brep --metrics volume,boundingBox
+echo '{"inputBrep":"part.brep"}' | occtkit metrics
+```
+
+### `query-topology`
+
+Find faces / edges / vertices matching criteria; return stable IDs for downstream calls.
+
+**Flag form:** `query-topology <input.brep> --entity face|edge|vertex [--filter '<json>'] [--limit N]`
+**JSON form:** `{ "inputBrep": "...", "entity": "face", "filter": {...}, "limit": N }`
+**Filter keys (all optional, AND-combined):** `surfaceType` (face), `curveType` (edge),
+`minArea`/`maxArea`, `minLength`/`maxLength`, `normalDirection`+`normalTolerance`.
+**Output:** `{ entity, results[{id,surfaceType?,curveType?,area?,length?,centerOfMass,normal?,boundingBox}], total, truncated }`.
+
+```bash
+query-topology part.brep --entity face --filter '{"surfaceType":"cylinder"}' --limit 50
+```
+
+### `measure-distance`
+
+Minimum distance and contacts between two BREPs (or a BREP and a point). Wraps
+`Shape.allDistanceSolutions(to:maxSolutions:)`.
+
+**Flag form:** `measure-distance <a.brep> <b.brep> [--from-ref <ref>] [--to-ref <ref>] [--compute-contacts]`.
+Refs (v1): `point:x,y,z` or omit for the whole shape.
+**JSON form:** `{ "a": "...", "b": "...", "fromRef": "...", "toRef": "...", "computeContacts": true }`
+**Output:** `{ minDistance, isParallel, contacts[{fromPoint,toPoint,distance}] }`.
+
+```bash
+measure-distance a.brep b.brep --compute-contacts
+```
+
+### `measure-deviation`
+
+Directed + symmetric surface deviation (one-sided / symmetric Hausdorff) between two
+BREPs — the fidelity metric a mesh→analytic reconstruction check needs. Mesh-based
+(tessellate both, project samples onto triangles).
+
+**Flag form:** `measure-deviation <a.brep> <b.brep> [--deflection D] [--max-samples N]`
+(`--deflection` default: 0.5% of the a-shape bbox diagonal; `--max-samples` default 20000).
+**JSON form:** `{ "a": "...", "b": "...", "deflection": D, "maxSamples": N }`
+**Output:** `{ deflection, fromToTo{max,rms,mean,worstPoint,samples}, toToFrom{...}, symmetricHausdorff }`.
+
+```bash
+measure-deviation source.brep reconstructed.brep --deflection 0.05
+```
+
+---
+
+## Drawings & export
+
+### `dxf-export`
+
+Project a BREP along a view direction (hidden-line-removed) and write a single-view
+DXF R12. Wraps `Exporter.writeDXF(shape:to:viewDirection:deflection:)`.
+
+**Input:** `dxf-export <shape.brep> <out.dxf> [--view x,y,z] [--deflection D]`
+(`--view` default `0,0,1` top-down; `--deflection` default `0.1`).
+**Output:** `{ output, view, deflection }`.
+
+```bash
+dxf-export bracket.brep bracket.dxf --view 0,0,1
+```
+
+<!-- drawing-export TODO: embed the rendered DXF preview for bracket.dxf -->
+
+### `drawing-export`
+
+Compose a complete **ISO 128-30 multi-view technical drawing** as DXF R12 — ISO 5457
+border + centring marks, ISO 7200 title block, ISO 5456-2 projection symbol, HLR
+orthographic views, auto-hatched section views (ISO 128-50), cutting-plane lines
+(ISO 128-40), auto-centerlines/centermarks, ISO 6410 cosmetic threads, ISO 1302
+surface-finish symbols, ISO 1101 GD&T frames, detail views, and user dimensions.
+CLI wrapper around the `DrawingComposer` library's `Composer.render(spec:shape:)`.
+
+**Input:** a `DrawingSpec` JSON on stdin or a file path. The CLI additionally requires
+`shape` (path to BREP) and `output` (path for the DXF) inside the spec. See
+[DrawingComposer.md](DrawingComposer.md) for the full schema.
+**Output:** `{ output, sheet, projection, scale, viewCount, sectionCount, detailCount }`.
+
+```bash
+echo '{"shape":"part.brep","output":"sheet.dxf","sheet":{"size":"a3","orientation":"landscape","projection":"third","scale":"auto"},"title":{"title":"Part"},"views":[{"name":"front"},{"name":"top"},{"name":"right"}]}' | drawing-export
+```
+
+<!-- drawing-export TODO: embed sheet.dxf rendered to PNG -->
+
+---
+
+## Composition
+
+### `reconstruct`
+
+Build a BREP from a JSON `[FeatureSpec]` payload via OCCTSwift's `FeatureReconstructor`.
+
+**Request schema (JSON object):** `outputDir` (required), `outputName?` (default
+`"reconstructed"`), `inputBrep?` (a starting body, registered under `@input` for
+boolean/fillet/chamfer references), `features[]` — each with a `kind` discriminator
+(`revolve` | `extrude` | `hole` | `thread` | `fillet` | `chamfer` | `boolean`) and
+snake_case fields.
+**Output:** `{ shape: "<path>.brep"|null, fulfilled[], skipped[{id,stage,reason,detail}], annotations[{id,kind,detail}] }`.
+Exit code `2` when no shape was produced from a non-empty feature list.
+
+```bash
+echo '{"outputDir":"/tmp/out","outputName":"shaft","features":[{"kind":"revolve","id":"shaft","profile_points_2d":[[0,0],[10,0],[10,40],[0,40]],"axis_origin":[0,0,0],"axis_direction":[0,0,1],"angle_deg":360}]}' | reconstruct
+```
+
+### `compose-sheet-metal`
+
+Compose a sheet-metal BREP from a JSON spec via OCCTSwift's `SheetMetal.Builder`.
+
+**Request schema:** `outputDir` (required), `outputName?` (default `"sheet-metal"`),
+`thickness`, `flanges[{id,profile:[[x,y]...],origin:[x,y,z],uAxis:[x,y,z],vAxis?:[x,y,z],normal:[x,y,z]}]`,
+`bends?[{from,to,radius}]`.
+**Output:** `{ shape, flanges, bends }`.
+
+```bash
+echo '{"outputDir":"/tmp/out","thickness":2,"flanges":[{"id":"base","profile":[[0,0],[60,0],[60,40],[0,40]],"origin":[0,0,0],"uAxis":[1,0,0],"normal":[0,0,1]}]}' | compose-sheet-metal
+```
+
+---
+
+## Construction
+
+### `transform`
+
+Apply translate → rotate → uniform-scale to a BREP, in declared order. Writes a new BREP.
+(OCCTSwift's `scaled(by:)` is uniform-only; non-uniform scale is rejected.)
+
+**Flag form:** `transform <input.brep> --output <out.brep> [--translate x,y,z]
+[--rotate-axis-angle x,y,z,radians | --rotate-euler-xyz x,y,z] [--scale s]`
+(axis-angle and euler are mutually exclusive).
+**JSON form:** `{ "inputBrep": "...", "outputPath": "...", "translate": [x,y,z],
+"rotateAxisAngle": [x,y,z,rad] | "rotateEulerXyz": [x,y,z], "scale": s|[x,y,z] }`
+**Output:** `{ outputPath, trsf: [16 floats — column-major 4×4] }`.
+
+```bash
+transform in.brep --output out.brep --translate 10,0,0 --rotate-axis-angle 0,0,1,1.5708
+```
+
+### `boolean`
+
+Boolean op (`union` | `subtract` | `intersect` | `split`) between two BREPs. `split`
+wraps its pieces in a compound.
+
+**Flag form:** `boolean --op <op> --a <a.brep> --b <b.brep> --output <out.brep>`
+**JSON form:** `{ "op": "...", "a": "...", "b": "...", "outputPath": "..." }`
+**Output:** `{ outputPath, volume?, isValid, warnings[] }`.
+
+```bash
+boolean --op subtract --a block.brep --b hole.brep --output cut.brep
+```
+
+### `pattern`
+
+Mirror / linear / circular pattern of a BREP, written as one BREP per instance
+(`pattern_0.brep`, `pattern_1.brep`, ...) into `--output-dir`.
+
+**Flag form:** `pattern <input.brep> --kind mirror|linear|circular --output-dir <dir> [kind flags]`
+— mirror: `--plane xy|yz|zx | --plane ox,oy,oz;nx,ny,nz`; linear: `--direction x,y,z --spacing s --count n`;
+circular: `--axis-origin x,y,z --axis-direction x,y,z --total-count n [--total-angle radians]`.
+**JSON form:** `{ "inputBrep": "...", "kind": "...", "outputDir": "...", ... }`
+**Output:** `{ outputPaths[], totalCount }`.
+
+```bash
+pattern bolt.brep --kind circular --axis-origin 0,0,0 --axis-direction 0,0,1 --total-count 6 --output-dir /tmp/bolts
+```
+
+---
+
+## I/O
+
+### `load-brep`
+
+Load a `.brep` and write a single-body `ScriptManifest` (`<id>.brep` + `manifest.json`)
+so OCCTSwiftViewport's ScriptWatcher picks it up — a no-compile equivalent of a one-line
+`ctx.add(...) + ctx.emit(...)` script.
+
+**Flag form:** `load-brep <input.brep> --emit-manifest <dir> [--id <bodyId>] [--color <hex>] [--allow-invalid]`
+**JSON form:** `{ "inputBrep": "...", "emitManifest": "...", "id": "...", "color": "#rrggbb|#rrggbbaa", "allowInvalid": bool }`
+**Output:** `{ bodyId, isValid, shapeType, faceCount, edgeCount, vertexCount, boundingBox{min,max} }`.
+
+```bash
+load-brep part.brep --emit-manifest ~/.occtswift-scripts/output --color "#7799bb"
+```
+
+### `import`
+
+Multi-format CAD import (STEP / IGES / STL / OBJ); writes one BREP per top-level body +
+a manifest. `--preserve-assembly` (STEP only) walks the XCAF assembly tree.
+
+**Flag form:** `import <input> --emit-manifest <dir> [--format auto|step|iges|stl|obj]
+[--id-prefix <p>] [--preserve-assembly] [--heal-on-import] [--allow-invalid]`
+(`--heal-on-import` is accepted but currently a no-op with a warning).
+**JSON form:** `{ "inputPath": "...", "emitManifest": "...", "format": "...", "idPrefix": "...", "preserveAssembly": bool, ... }`
+**Output:** `{ addedBodyIds[], assembly{rootId,components[...]}|null, warnings[] }`.
+
+```bash
+import widget.step --emit-manifest /tmp/out --preserve-assembly
+```
+
+---
+
+## Engineering analysis
+
+### `check-thickness`
+
+Wall-thickness analysis: sample each face on a UV grid, cast an inward ray, report
+min / max / mean thickness and flag thin regions. Pure read.
+
+**Flag form:** `check-thickness <input.brep> [--min-acceptable d] [--sampling-density coarse|medium|fine]`
+(grid 4 / 8 / 16; default `medium`).
+**JSON form:** `{ "inputBrep": "...", "minAcceptable": d, "samplingDensity": "..." }`
+**Output:** `{ minThickness?, maxThickness?, meanThickness?, thinRegions[{centerPoint,thickness,faceRefs}], samples }`.
+
+```bash
+check-thickness shell.brep --min-acceptable 1.5 --sampling-density fine
+```
+
+### `analyze-clearance`
+
+Pairwise interference / minimum-clearance check between two or more BREPs. When a pair's
+min distance is 0, also reports the interference volume (solid×solid).
+
+**Flag form:** `analyze-clearance <a.brep> <b.brep> [<c.brep>...] [--min-clearance d] [--max-contacts N] [--no-contacts]`
+**JSON form:** `{ "inputs": ["a.brep","b.brep",...], "minClearance": d, "maxContacts": N, "computeContacts": bool }`
+**Output:** `{ pairs[{a,b,minDistance,intersects,belowMinClearance?,contacts[],interferenceVolume?}] }`.
+
+```bash
+analyze-clearance shaft.brep housing.brep --min-clearance 0.5
+```
+
+### `heal`
+
+Heal imported / non-watertight geometry via OCCTSwift's `ShapeFixer`. Writes a new BREP
+and reports before/after stats. (Per-fix `--fix-*` flags are accepted for forward
+compatibility but currently coalesce into precision tuning.)
+
+**Flag form:** `heal <input.brep> --output <out.brep> [--tolerance d] [--max-tolerance d]
+[--min-tolerance d] [--fix-small-edges] [--fix-small-faces] [--fix-gaps]
+[--fix-self-intersection] [--fix-orientation] [--unify-domain]`
+**JSON form:** `{ "inputBrep": "...", "outputPath": "...", "tolerance": d, ... }`
+**Output:** `{ outputPath, before{...}, after{...}, fixes{smallEdgesFixed,smallFacesFixed,freeEdgesClosed,selfIntersectionsResolved}, warnings[] }`.
+
+```bash
+heal imported.brep --output healed.brep --tolerance 0.01
+```
+
+---
+
+## Mesh
+
+### `mesh`
+
+Generate a triangle mesh from a BREP via `BRepMesh_IncrementalMesh`; report counts +
+quality metrics. Geometry is returned inline up to 100K triangles, else written to
+`--output` (`.stl` / `.obj`).
+
+**Flag form:** `mesh <input.brep> [--linear-deflection d] [--angular-deflection d]
+[--parallel] [--output <path.stl|.obj>] [--no-return-geometry]`
+(defaults: linear `0.1`, angular `0.5`).
+**JSON form:** `{ "inputBrep": "...", "linearDeflection": d, "angularDeflection": d, "parallel": bool, "outputPath": "...", "returnGeometry": bool }`
+**Output:** `{ triangleCount, vertexCount, quality{minAspectRatio,meanAspectRatio,degenerateTriangles,nonManifoldEdges}, geometry?{vertices,indices}, outputPath? }`.
+
+```bash
+mesh part.brep --linear-deflection 0.05 --output part.stl
+```
+
+### `simplify-mesh`
+
+QEM mesh decimation to a target triangle count, via `OCCTSwiftMesh`'s `Mesh.simplified(_:)`.
+
+**Flag form:** `simplify-mesh <input.brep> (--target-triangle-count N | --target-reduction R)
+[--preserve-boundary] [--preserve-topology] [--max-hausdorff-distance d]
+[--linear-deflection d] [--angular-deflection d] --output <path.stl|.obj>`
+**JSON form:** `{ "inputBrep": "...", "outputPath": "...", "targetTriangleCount": N | "targetReduction": R, ... }`
+**Output:** `{ beforeTriangleCount, afterTriangleCount, qualityDelta{meanAspectRatioDelta,hausdorffDistance}, outputPath }`.
+
+```bash
+simplify-mesh part.brep --target-reduction 0.5 --output part-lod.obj
+```
+
+---
+
+## Render
+
+### `render-preview`
+
+Render a PNG preview of one or more BREPs at a named camera angle, headless, via
+OCCTSwiftViewport's `OffscreenRenderer`. **This repo owns `render-preview`** — it is the
+ecosystem's way to embed 3D previews in docs and reports.
+
+**Flag form:** `render-preview <brep>... --output <png>
+[--camera iso|front|back|top|bottom|left|right]
+[--camera-position x,y,z --camera-target x,y,z [--camera-up x,y,z]]
+[--width N] [--height N]
+[--display-mode shaded|wireframe|shaded-with-edges|flat|xray|rendered]
+[--background light|dark|transparent|#hex]
+[--show-axes] [--axes-position origin|center|outside|x,y,z]
+[--show-workplane xy|yz|xz]
+[--highlight face[N],edge[M],vertex[K]] [--highlight-color #hex]`
+(defaults: `--camera iso`, `--width 800`, `--height 600`, `--display-mode shaded`,
+`--background light`).
+**JSON form:** `{ "inputs": ["a.brep",...], "outputPath": "...", "camera": "iso", "width": N, ... }`
+**Output:** `{ outputPath, width, height, mimeType: "image/png" }`.
+
+```bash
+render-preview part.brep --output part.png --camera iso --display-mode shaded-with-edges
+render-preview part.brep --output hl.png --highlight 'face[3],edge[7]' --highlight-color '#ffa500'
+```
+
+<!-- 3D render TODO: render-preview output for part.png -->
+
+---
+
+## XCAF
+
+### `inspect-assembly`
+
+Walk an XCAF document's assembly tree and report hierarchy + per-component metadata.
+Inputs auto-detected by extension: `.step`/`.stp` and `.xbf` (OCAF binary) carry the tree;
+`.brep` returns a degenerate single-node response.
+
+**Flag form:** `inspect-assembly <input> [--depth N]`
+**JSON form:** `{ "inputPath": "...", "depth": N }`
+**Output:** `{ root{id,name,isAssembly,transform,color?,...,children[],referredTo?}, totalComponents, totalInstances, totalReferences }`.
+Stable label IDs are `label_<int64>` and round-trip into `set-metadata --component-id`.
+
+```bash
+inspect-assembly gearbox.step --depth 3
+```
+
+### `set-metadata`
+
+Write document- or component-level XCAF metadata onto an OCAF document and save it as
+`.xbf`. (STEP write-back is not done in v1.) Title-block keys at document scope:
+`title / drawnBy / material / weight / revision / partNumber`.
+
+**Flag form:** `set-metadata <input> --output <out.xbf> [--scope document|component]
+[--component-id <int64>] [--title <s>] [--drawn-by <s>] [--material <s>] [--weight <n>]
+[--revision <s>] [--part-number <s>] [--custom-attr key=value]` (repeatable).
+**JSON form:** `{ "inputPath": "...", "outputPath": "...", "scope": "document", "title": "...", "customAttrs": {"k":"v"} }`
+**Output:** `{ outputPath, applied{key:value} }`.
+
+```bash
+set-metadata gearbox.step --output gearbox.xbf --title "Gearbox" --material "EN-GJL-250" --revision B
+```


### PR DESCRIPTION
## Summary

Adds consolidated, context7-compliant documentation for the `occtkit` CLI and the
`ScriptHarness` / `DrawingComposer` libraries, plus a tightened root `context7.json`.
Everything is grounded in source — every documented verb, flag, JSON field, and API
symbol was read out of `Sources/` (no invented APIs).

### New / updated docs
- **`docs/reference/occtkit-verbs.md`** — all **29** occtkit verbs (the full
  `Registry.all` set, including `graph-select`). Each verb has its purpose, flag-form
  and JSON-form inputs, the JSON it writes to stdout, and a runnable CLI example.
- **`docs/reference/ScriptHarness.md`** — `ScriptContext` (init/output dirs, `add`
  overloads for Shape/Wire/Edge, `addCompound`, `addGraph`, `emit`, `Colors`), the
  manifest `Codable` types, and `ScriptError`, with runnable Swift snippets.
- **`docs/reference/DrawingComposer.md`** — the three `Composer.render` overloads
  (shape / components / document), `DrawingComposerResult`, and the full `DrawingSpec`
  schema (sheet, title block, views, sections, details, annotations, dimensions), with
  runnable Swift + a full JSON spec example.
- **`docs/guides/getting-started.md`** — refreshed; cross-links the three new reference
  pages, adds JSON-form / `--serve` / `render-preview` examples.

### `context7.json`
- `description` rewritten to **≤200 chars** (184).
- Every `rule` is **≤255 chars**; 10 rules cover running verbs, JSON-driven invocation,
  the `--serve` envelope, OCCTMCP integration, stable topology IDs, and `render-preview`.
- `folders`: `docs`, `Sources/ScriptHarness`, `Sources/DrawingComposer`, `Sources/occtkit`, `recipes` (all exist).
- `excludeFolders` now includes **`okf`** (plus `Tests`, `.build`, `Scripts`, `.swiftpm`, `docs/knowledge`).

### Render / drawing markers
This repo owns `render-preview`, so where a 3D preview or drawing export would help, the
docs carry `<!-- 3D render TODO: render-preview output -->` and
`<!-- drawing-export TODO: ... -->` markers (no links to non-existent images yet).

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)