### PR TITLE
docs(okf): add mandatory context-first docs policy

### DIFF
--- a/okf/index.md
+++ b/okf/index.md
@@ -27,3 +27,7 @@ See [`components/`](components/index.md) for the public surface.
 ## References
 
 See [`references/`](references/index.md) for the workflow guide, recipes cookbook, package index, and upstream links.
+
+## Policies
+
+- [Query `context` first for OCCT / OCCTSwift docs](policies/context-first.md)

--- a/okf/index.md
+++ b/okf/index.md
@@ -31,3 +31,4 @@ See [`references/`](references/index.md) for the workflow guide, recipes cookboo
 ## Policies
 
 - [Query `context` first for OCCT / OCCTSwift docs](policies/context-first.md)
+- [Documentation updates are mandatory](policies/docs-current.md)

--- a/okf/policies/context-first.md
+++ b/okf/policies/context-first.md
@@ -1,24 +1,27 @@
 ---
 type: policy
-title: Query `context` first for OCCT / OCCTSwift docs
-description: Agents must consult the context MCP for OCCT/OCCTSwift APIs before relying on training data.
-tags: [policy, docs, context, agents]
+title: Documentation lookup — `context` first
+description: Look docs up via context (ecosystem), context7 (external), then other repos' docs — never training-data recall.
+tags: [policy, docs, context, context7, agents]
 timestamp: 2026-06-27
 ---
 
-# Query `context` first
+# Documentation lookup — `context` first
 
-When answering or writing code that touches **OCCT** or the **OCCTSwift** API, you **MUST** consult the
-`context` MCP before relying on training-data recall of OCCT/OCCTSwift signatures — it is stale and
-wrong for this fast-moving stack.
+When answering or writing code that touches **OCCT** or the **OCCTSwift** API, you **MUST** look the
+documentation up rather than relying on training-data recall of OCCT/OCCTSwift signatures — it is
+stale and wrong for this fast-moving stack.
 
-Use `mcp__context__get_docs(library=…, topic=…)` with:
+**Lookup order:**
 
-- **`occt`** — the underlying OpenCASCADE kernel (V8_0_0_p1 overview / user guides).
-- **`occtswift`** — the Swift wrapper API.
-- **this repo's own package** — its `context` library, where indexed.
+1. **`context` MCP** (`mcp__context__get_docs`) — the primary source for all ecosystem docs:
+   `occt` (the OpenCASCADE kernel, V8_0_0_p1 overview), `occtswift` (the Swift wrapper), this repo's
+   own package, and the other OCCTSwift-family packages indexed there.
+2. **context7** — for **external** / third-party libraries that aren't in the local `context` cache.
+3. **Docs in the other ecosystem repos** (their `okf/`, `docs/`, READMEs) — the fallback when a topic
+   isn't indexed in either.
 
-The reference manual (per-class Doxygen API) is not indexed: read the bundled
+The OCCT reference manual (per-class Doxygen API) is not indexed: read the bundled
 `OCCT.xcframework/.../Headers/*.hxx`, or WebFetch `dev.opencascade.org/doc/refman/html/class_*.html`
 for a specific class.
 

--- a/okf/policies/context-first.md
+++ b/okf/policies/context-first.md
@@ -1,0 +1,26 @@
+---
+type: policy
+title: Query `context` first for OCCT / OCCTSwift docs
+description: Agents must consult the context MCP for OCCT/OCCTSwift APIs before relying on training data.
+tags: [policy, docs, context, agents]
+timestamp: 2026-06-27
+---
+
+# Query `context` first
+
+When answering or writing code that touches **OCCT** or the **OCCTSwift** API, you **MUST** consult the
+`context` MCP before relying on training-data recall of OCCT/OCCTSwift signatures — it is stale and
+wrong for this fast-moving stack.
+
+Use `mcp__context__get_docs(library=…, topic=…)` with:
+
+- **`occt`** — the underlying OpenCASCADE kernel (V8_0_0_p1 overview / user guides).
+- **`occtswift`** — the Swift wrapper API.
+- **this repo's own package** — its `context` library, where indexed.
+
+The reference manual (per-class Doxygen API) is not indexed: read the bundled
+`OCCT.xcframework/.../Headers/*.hxx`, or WebFetch `dev.opencascade.org/doc/refman/html/class_*.html`
+for a specific class.
+
+Ecosystem standard — see
+[OKF-STANDARD.md](https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md).

--- a/okf/policies/docs-current.md
+++ b/okf/policies/docs-current.md
@@ -1,0 +1,21 @@
+---
+type: policy
+title: Documentation updates are mandatory
+description: Docs must be updated with every release — or every PR for repos not yet on stable semver.
+tags: [policy, docs, release, semver]
+timestamp: 2026-06-27
+---
+
+# Documentation updates are mandatory
+
+Documentation — the `context`-indexed docs, this repo's `okf/` bundle, and any public API reference —
+must not drift from the code:
+
+- **Repos on stable semver (≥ 1.0):** every **release** must ship the matching documentation update.
+  A release that changes public API or behaviour without updating the docs is incomplete.
+- **Repos not yet on semver (0.x / pre-release / untagged):** every **PR** that changes public API or
+  behaviour must update the docs in the same PR.
+
+This is the other half of the [`context-first`](context-first.md) contract: agents query the
+`context` docs (`occt`, `occtswift`, this package) as the source of truth, so those docs must be
+current — stale docs are worse than none.


### PR DESCRIPTION
Adds the mandatory context-first docs policy to this repo's okf/ bundle (ecosystem OKF-STANDARD.md): agents must query the context MCP (occt / occtswift / this package) for OCCT/OCCTSwift docs before relying on training data. New okf/policies/context-first.md + link in okf/index.md.