### PR TITLE
docs(okf): make docs-current a thin pointer to Release discipline

### DIFF
--- a/okf/policies/docs-current.md
+++ b/okf/policies/docs-current.md
@@ -1,21 +1,19 @@
 ---
 type: policy
 title: Documentation updates are mandatory
-description: Docs must be updated with every release — or every PR for repos not yet on stable semver.
+description: Docs update with every release — or every PR for repos not yet on stable semver. See Release discipline.
 tags: [policy, docs, release, semver]
 timestamp: 2026-06-27
 ---
 
 # Documentation updates are mandatory
 
-Documentation — the `context`-indexed docs, this repo's `okf/` bundle, and any public API reference —
-must not drift from the code:
+Documentation updates ship **with the change**, never as a follow-up: every **release** for repos on
+stable semver (≥ 1.0), and every **PR** that changes a public API surface for repos not yet on semver
+(0.x / untagged).
 
-- **Repos on stable semver (≥ 1.0):** every **release** must ship the matching documentation update.
-  A release that changes public API or behaviour without updating the docs is incomplete.
-- **Repos not yet on semver (0.x / pre-release / untagged):** every **PR** that changes public API or
-  behaviour must update the docs in the same PR.
-
-This is the other half of the [`context-first`](context-first.md) contract: agents query the
-`context` docs (`occt`, `occtswift`, this package) as the source of truth, so those docs must be
-current — stale docs are worse than none.
+For exactly what to update each time — `README.md`, the API reference, the changelog, the relevant
+reference page, and in-source doc comments with runnable examples — follow the authoritative
+**Release discipline** in
+[OKF-STANDARD.md](https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md) and the repo's
+`CLAUDE.md` Release Process.


### PR DESCRIPTION
Trims okf/policies/docs-current.md to a short pointer to the authoritative Release discipline (OKF-STANDARD.md / CLAUDE.md), avoiding duplicated docs-currency text.