### PR TITLE
fix(deps): cap OCCTSwiftIO minor + fix sibling-detection false-positive (#69)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,19 @@ func occtDep(_ name: String, from version: String) -> Package.Dependency {
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", from: Version(version)!)
 }
 
+// As occtDep, but pins to the package's minor line instead of an open major range. Used to cap a
+// transitive dependency whose newer minors pull deps we don't want in the graph — OCCTSwiftIO 1.1.0+
+// pulls in the heavy mesh-IO stack (SwiftX/SwiftDXF/SwiftJWW/SwiftPMX/ThreeMF/SwiftGLTF/…), which the
+// narrow GraphML/graphml usage here doesn't need and which breaks resolution for lean consumers that
+// have no root package to override from (ecosystem issue: OCCTSwiftScripts#69).
+func occtDepUpToNextMinor(_ name: String, from version: String) -> Package.Dependency {
+    let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+        return .package(path: "../\(name)")
+    }
+    return .package(url: "https://github.com/SecondMouseAU/\(name).git", .upToNextMinor(from: Version(version)!))
+}
+
 let package = Package(
     name: "OCCTSwiftScripts",
     platforms: [
@@ -92,7 +105,9 @@ let package = Package(
         // v0.171.0 hoisted them out of the kernel. Pulled into GraphML and
         // graphml verbs only — the rest of the package keeps its existing
         // ScriptManifest type (with the `graphs` field) from ScriptHarness.
-        occtDep("OCCTSwiftIO", from: "1.0.0"),
+        // Capped to the 1.0.x minor line (occtDepUpToNextMinor): 1.1.0+ pulls in the
+        // heavy mesh-IO stack this narrow usage doesn't need (#69).
+        occtDepUpToNextMinor("OCCTSwiftIO", from: "1.0.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,23 @@ import Foundation
 // OCCT ecosystem SHARES the single OCCTSwift/Libraries/OCCT.xcframework instead of each repo
 // extracting its own 1.3 GB copy. CI / fresh clones (no sibling) use the URL pin. `#filePath`-relative
 // so it's independent of build CWD.
+// Only trust a sibling checkout when THIS manifest is a real local dev clone — never when this
+// manifest is itself a transitively-resolved SwiftPM checkout (.build/checkouts/<repo>/Package.swift).
+// SwiftPM lays every dependency's checkout out flat under one shared `checkouts/` directory, so once
+// e.g. `.build/checkouts/OCCTSwiftIO` exists, `../OCCTSwiftIO` relative to
+// `.build/checkouts/OCCTSwiftScripts` spuriously "exists" too — flipping this manifest's own
+// declaration from url to path *during* the resolution process that created that checkout. SwiftPM
+// then sees a non-deterministic manifest and reports the whole graph unresolvable ("exhausted
+// attempts to resolve the dependencies graph") for every lean consumer that pulls this package in
+// transitively — the actual mechanism behind ecosystem issue #69, beyond the OCCTSwiftIO version cap.
+private func isRealLocalSibling(_ manifestDir: String, _ name: String) -> Bool {
+    guard !manifestDir.contains("/checkouts/") else { return false }
+    return FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift")
+}
+
 func occtDep(_ name: String, from version: String) -> Package.Dependency {
     let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+    if isRealLocalSibling(manifestDir, name) {
         return .package(path: "../\(name)")
     }
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", from: Version(version)!)
@@ -21,7 +35,7 @@ func occtDep(_ name: String, from version: String) -> Package.Dependency {
 // have no root package to override from (ecosystem issue: OCCTSwiftScripts#69).
 func occtDepUpToNextMinor(_ name: String, from version: String) -> Package.Dependency {
     let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+    if isRealLocalSibling(manifestDir, name) {
         return .package(path: "../\(name)")
     }
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", .upToNextMinor(from: Version(version)!))

--- a/Package.swift
+++ b/Package.swift
@@ -7,16 +7,18 @@ import Foundation
 // extracting its own 1.3 GB copy. CI / fresh clones (no sibling) use the URL pin. `#filePath`-relative
 // so it's independent of build CWD.
 // Only trust a sibling checkout when THIS manifest is a real local dev clone — never when this
-// manifest is itself a transitively-resolved SwiftPM checkout (.build/checkouts/<repo>/Package.swift).
-// SwiftPM lays every dependency's checkout out flat under one shared `checkouts/` directory, so once
+// manifest is itself a transitively-resolved SwiftPM checkout under a consumer's `.build/`. SwiftPM
+// lays every dependency's checkout out flat under one shared `.build/checkouts/` directory, so once
 // e.g. `.build/checkouts/OCCTSwiftIO` exists, `../OCCTSwiftIO` relative to
 // `.build/checkouts/OCCTSwiftScripts` spuriously "exists" too — flipping this manifest's own
 // declaration from url to path *during* the resolution process that created that checkout. SwiftPM
 // then sees a non-deterministic manifest and reports the whole graph unresolvable ("exhausted
 // attempts to resolve the dependencies graph") for every lean consumer that pulls this package in
 // transitively — the actual mechanism behind ecosystem issue #69, beyond the OCCTSwiftIO version cap.
+// Same guard OCCTSwiftIO adopted (2026-06-23, "don't path-link siblings when resolved under a
+// consumer's .build") — kept as `/.build/` here for consistency across the fleet.
 private func isRealLocalSibling(_ manifestDir: String, _ name: String) -> Bool {
-    guard !manifestDir.contains("/checkouts/") else { return false }
+    guard !manifestDir.contains("/.build/") else { return false }
     return FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift")
 }
 


### PR DESCRIPTION
Closes #69. Two fixes — the reported one plus a deeper root cause found while reproducing it exactly.

## 1. Cap OCCTSwiftIO to its 1.0.x minor line (the reported bug)
`occtDep("OCCTSwiftIO", from: "1.0.0")` only bounds by major version, so a lean consumer with no root-level override (e.g. OCCTMCP's `execute_script` workspace) floats OCCTSwiftIO to whatever 1.x is newest — now **v1.5.0**, which drags in the heavy mesh-IO stack (SwiftX/SwiftDXF/SwiftJWW/SwiftPMX/ThreeMF/SwiftGLTF/…). This repo only uses OCCTSwiftIO for `TopologyGraph.exportForML`/`exportJSON` (GraphML/graphml verbs), which has needed nothing past 1.0.x. Adds `occtDepUpToNextMinor` (same helper [OCCTMCP#53](https://github.com/SecondMouseAU/OCCTMCP/issues/53) already uses) and caps through it.

## 2. Fix a false-positive in the sibling-path detection (the actual remaining blocker)
Capping the version alone **did not** fix resolution for a lean consumer — I reproduced the exact failure with a standalone package depending only on `OCCTSwiftScripts`'s `ScriptHarness` product (mirroring `execute_script`'s workspace) and still hit `error: exhausted attempts to resolve the dependencies graph`, even with OCCTSwiftIO correctly computed at 1.0.1.

Root cause: `occtDep`'s sibling probe (`../<name>/Package.swift`) is purely filesystem-based. SwiftPM lays every dependency's checkout out **flat** under one shared `.build/checkouts/` directory — so once `.build/checkouts/OCCTSwiftIO` exists (as a side effect of resolving it), `../OCCTSwiftIO` relative to `.build/checkouts/OCCTSwiftScripts` spuriously "exists" too, flipping *this manifest's own* dependency declaration from `url` to `path` **mid-resolution**. SwiftPM sees a non-deterministic manifest and reports the whole graph unresolvable — for **any** consumer that pulls OCCTSwiftScripts in transitively, not just ones affected by the version float.

Fix: the sibling check is now guarded on the manifest's own directory **not** being inside a `/checkouts/` path — a real local dev clone (`~/Projects/<repo>`) never is; only a transitively-resolved SwiftPM checkout is.

## Verified
- `swift package resolve` in a standalone "depends on OCCTSwiftScripts only" package (before either fix): reproduces the reported failure exactly (OCCTSwiftIO floats to 1.5.0, pulls in `tomasf/Zip`, `exhausted attempts`).
- After fix 1 alone: still `exhausted attempts` (OCCTSwiftIO correctly at 1.0.1, but the sibling false-positive still poisons the graph).
- After both fixes: **resolves and builds cleanly** — OCCTSwiftIO pinned at 1.0.1, no heavy mesh-IO packages in the graph.
- OCCTSwiftScripts' own `swift build` + `swift test --no-parallel`: clean, 3/3 tests pass.

## Follow-up worth considering separately
The sibling-detection pattern (`occtDep`/`occtDepUpToNextMinor`) is copy-pasted across the ecosystem's `Package.swift` files. The same false-positive could latently affect any of them once used as a transitive dependency (as opposed to built directly from a real local clone) — happy to sweep the fleet with the same guard if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)